### PR TITLE
provision after restart

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -71,7 +71,7 @@ public class MesosCloud extends Cloud {
 
   private static final Logger LOGGER = Logger.getLogger(MesosCloud.class.getName());
 
-  private static volatile boolean mesosLibInitialized = false;
+  private static volatile boolean nativeLibraryLoaded = false;
 
   @DataBoundConstructor
   public MesosCloud(String nativeLibraryPath, String master, String description, int slaveCpus,
@@ -95,7 +95,7 @@ public class MesosCloud extends Cloud {
 
   private synchronized void handleMesosSetup() {
 
-    if(!mesosLibInitialized) {
+    if(!nativeLibraryLoaded) {
       // First, we attempt to load the library from the given path.
       // If unsuccessful, we attempt to load using 'MesosNativeLibrary.load()'.
       try {
@@ -105,7 +105,7 @@ public class MesosCloud extends Cloud {
         	             "': " + error.getMessage());
       	MesosNativeLibrary.load();
       }	
-      mesosLibInitialized = true;
+      nativeLibraryLoaded = true;
     }
 
     // Restart the scheduler if the master has changed or a scheduler is not up.


### PR DESCRIPTION
This pull request is aiming to address the following.
1. After Jenkins restart, scheduler is not started.
2. Hence, if there were pending builds in the queue, they are never provisioned.
3. User can start new builds without first going to again save the plugin info.

When the provision method is called after restart for builds, the actual member field values saved by the plugin earlier have already been set to the field members and defaults for the not modifiable.

I also never found the DescriptorImpl::configure() method to be called. Based on what I read here,
https://wiki.jenkins-ci.org/display/JENKINS/Basic+guide+to+Jelly+usage+in+Jenkins
if @DataBoundCtr is defined then configure not required. But I did not remove it.
