### PR TITLE
Making framework name configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # Eclude Eclipse files that can be generated with mvn eclipse:eclipse
 .classpath
 .project
+.settings/
 target/
+work/
 
 # Used as a local build/deploy dev-cycle script
 deploy.sh

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -62,15 +62,17 @@ public class JenkinsScheduler implements Scheduler {
   private volatile MesosSchedulerDriver driver;
   private final String jenkinsMaster;
   private final String mesosMaster;
-
+  private final String frameworkName;
+  
   private static final Logger LOGGER = Logger.getLogger(JenkinsScheduler.class.getName());
 
-  public JenkinsScheduler(String jenkinsMaster, String mesosMaster) {
+  public JenkinsScheduler(String jenkinsMaster, String mesosMaster, String frameworkName) {
     LOGGER.info("JenkinsScheduler instantiated with jenkins " + jenkinsMaster +
         " and mesos " + mesosMaster);
 
     this.jenkinsMaster = jenkinsMaster;
     this.mesosMaster = mesosMaster;
+    this.frameworkName = frameworkName;
 
     requests = new LinkedList<Request>();
     results = new HashMap<TaskID, Result>();
@@ -83,7 +85,7 @@ public class JenkinsScheduler implements Scheduler {
       public void run() {
         // Have Mesos fill in the current user.
         FrameworkInfo framework = FrameworkInfo.newBuilder().setUser("")
-            .setName("Jenkins Framework").build();
+            .setName(JenkinsScheduler.this.frameworkName).build();
 
         driver = new MesosSchedulerDriver(JenkinsScheduler.this, framework, mesosMaster);
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
@@ -45,7 +45,7 @@ public abstract class Mesos {
     void failed(JenkinsSlave slave);
   }
 
-  abstract public void startScheduler(String jenkinsMaster, String mesosMaster);
+  abstract public void startScheduler(String jenkinsMaster, String mesosMaster, String frameworkName);
   abstract public boolean isSchedulerRunning();
   abstract public void stopScheduler();
 
@@ -81,9 +81,9 @@ public abstract class Mesos {
 
   public static class MesosImpl extends Mesos {
     @Override
-    public synchronized void startScheduler(String jenkinsMaster, String mesosMaster) {
+    public synchronized void startScheduler(String jenkinsMaster, String mesosMaster, String frameworkName) {
       stopScheduler();
-      scheduler = new JenkinsScheduler(jenkinsMaster, mesosMaster);
+      scheduler = new JenkinsScheduler(jenkinsMaster, mesosMaster, frameworkName);
       scheduler.init();
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -10,6 +10,10 @@
     <f:entry title="${%Description}">
         <f:textbox field="description" />
     </f:entry>
+    
+    <f:entry title="${%Framework Name}">
+        <f:textbox field="frameworkName" value="Jenkins Schedular" />
+    </f:entry>
 
     <f:advanced>
         <f:entry title="${%Jenkins Slave CPUs}">


### PR DESCRIPTION
Framework name should be configurable in environments where multiple Jenkins Master/JenkinsSchedulars run against common mesos. It helps distinguishing one from another.
