### PR TITLE
CPU shares can be double values for Slave and Executor

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
@@ -27,10 +27,10 @@ public abstract class Mesos {
 
   public static class SlaveRequest {
     JenkinsSlave slave;
-    final int cpus;
+    final double cpus;
     final int mem;
 
-    public SlaveRequest(JenkinsSlave slave, int cpus, int mem) {
+    public SlaveRequest(JenkinsSlave slave, double cpus, int mem) {
       this.slave = slave;
       this.cpus = cpus;
       this.mem = mem;

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
@@ -69,7 +69,7 @@ public class MesosComputerLauncher extends ComputerLauncher {
     }
 
     // Create the request.
-    int cpus = computer.getNode().getCpus();
+    double cpus = computer.getNode().getCpus();
     int mem = computer.getNode().getMem();
     Mesos.SlaveRequest request = new Mesos.SlaveRequest(new JenkinsSlave(name), cpus, mem);
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -16,17 +16,14 @@ package org.jenkinsci.plugins.mesos;
 
 import hudson.Extension;
 import hudson.model.Computer;
-import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Hudson;
 import hudson.model.Slave;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.ComputerLauncher;
-import hudson.slaves.RetentionStrategy;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -34,7 +31,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 public class MesosSlave extends Slave {
 
-  private final int cpus;
+  private final double cpus;
   private final int mem;
 
   private static final Logger LOGGER = Logger.getLogger(MesosSlave.class
@@ -42,7 +39,7 @@ public class MesosSlave extends Slave {
 
   @DataBoundConstructor
   public MesosSlave(String name, int numExecutors, String labelString,
-      int slaveCpus, int slaveMem, int executorCpus, int executorMem,
+      double slaveCpus, int slaveMem, double executorCpus, int executorMem,
       int idleTerminationMinutes) throws FormException, IOException
   {
     super(name,
@@ -61,7 +58,7 @@ public class MesosSlave extends Slave {
     LOGGER.info("Constructing Mesos slave");
   }
 
-  public int getCpus() {
+  public double getCpus() {
     return cpus;
   }
 

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -17,7 +17,7 @@
 
     <f:advanced>
         <f:entry title="${%Jenkins Slave CPUs}">
-            <f:number field="slaveCpus" clazz="required positive-number"  value="1"/>
+            <f:textbox field="slaveCpus" clazz="required" value="1"/>
         </f:entry>
 
         <f:entry title="${%Jenkins Slave Memory in MB}">
@@ -29,7 +29,7 @@
         </f:entry>
 
         <f:entry title="${%Jenkins Executor CPUs}">
-            <f:number field="executorCpus" clazz="required number" value="1"/>
+            <f:textbox field="executorCpus" clazz="required" value="1"/>
         </f:entry>
 
         <f:entry title="${%Jenkins Executor Memory in MB}">


### PR DESCRIPTION
- This commit updates Jenkins plugin to accept double values for slave
  and executor CPUs
