### PR TITLE
Adding the checkpointing boolean flag as a new cloud config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Ensure Mesos slaves have a `jenkins` user or the user the Jenkins master is runn
 Mesos slaves can be tagged with attributes. This feature allows the Jenkins scheduler to pick specific
 Mesos slaves based on attributes specified in JSON format. Ex. {"clusterType":"jenkinsSlave"}
 
+### Mesos slave checkpointing ###
+
+Checkpointing can now be enabled by setting the "Slave Checkpointing" option to yes in the cloud config. This will allow the Jenkins
+master to finish running its slave jobs even if the Mesos slave process temporarily goes down.
 
 ### Configuring Jenkins jobs ###
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
       <dependency>
           <groupId>org.apache.mesos</groupId>
           <artifactId>mesos</artifactId>
-          <version>0.13.0</version>
+          <version>0.17.0</version>
       </dependency>
       <dependency>
           <groupId>com.google.protobuf</groupId>

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -79,8 +79,16 @@ public class JenkinsScheduler implements Scheduler {
       @Override
       public void run() {
         // Have Mesos fill in the current user.
-        FrameworkInfo framework = FrameworkInfo.newBuilder().setUser("")
-            .setName(JenkinsScheduler.this.getMesosCloud().getFrameworkName()).build();
+        FrameworkInfo framework = FrameworkInfo.newBuilder()
+          .setUser("")
+          .setName(mesosCloud.getFrameworkName())
+          .setCheckpoint(mesosCloud.isCheckpoint()).build();
+
+        LOGGER.info("Initializing the Mesos driver with options"
+        + "\n" + "User: " + framework.getUser()
+        + "\n" + "Framework Name: " + framework.getName()
+        + "\n" + "Checkpointing: " + framework.getCheckpoint()
+        );
 
         driver = new MesosSchedulerDriver(JenkinsScheduler.this, framework, mesosCloud.getMaster());
 

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -10,39 +10,46 @@
     <f:entry title="${%Description}">
         <f:textbox field="description" />
     </f:entry>
-
+    
     <f:entry title="${%Framework Name}">
-        <f:textbox field="frameworkName" value="Jenkins Scheduler" />
+        <f:textbox field="frameworkName" default="Jenkins Scheduler" />
     </f:entry>
 
     <f:advanced>
         <f:entry title="${%Jenkins Slave CPUs}">
-            <f:textbox field="slaveCpus" clazz="required" value="1"/>
+            <f:textbox field="slaveCpus" clazz="required" default="0.1"/>
         </f:entry>
 
         <f:entry title="${%Jenkins Slave Memory in MB}">
-            <f:number field="slaveMem" clazz="required positive-number" value="512"/>
+            <f:number field="slaveMem" clazz="required positive-number" default="512"/>
         </f:entry>
 
         <f:entry title="${% Maximum number of Executors per Slave}">
-            <f:number field="maxExecutors" clazz="required number" value="2"/>
+            <f:number field="maxExecutors" clazz="required number" default="2"/>
         </f:entry>
 
         <f:entry title="${%Jenkins Executor CPUs}">
-            <f:textbox field="executorCpus" clazz="required" value="1"/>
+            <f:textbox field="executorCpus" clazz="required" default="0.1"/>
         </f:entry>
 
         <f:entry title="${%Jenkins Executor Memory in MB}">
-            <f:number field="executorMem" clazz="required positive-number" value="128"/>
+            <f:number field="executorMem" clazz="required positive-number" default="128"/>
         </f:entry>
 
         <f:entry title="${%Idle Termination Minutes}">
-            <f:number field="idleTerminationMinutes" clazz="required positive-number" value="3"/>
+            <f:number field="idleTerminationMinutes" clazz="required positive-number" default="3"/>
         </f:entry>
 
         <f:entry title="${%Mesos Offer Selection Attributes}">
             <f:textbox field="slaveAttributes"/>
-        </f:entry>        
+        </f:entry>
+
+        <f:entry title="${%Slave Checkpointing}" description="${%Enable Mesos slave checkpointing?}">
+            <f:radio name="checkpoint" value="true" checked="${instance.checkpoint == true}" id="checkpoint.true"/>
+            <st:nbsp/>${%Yes}
+            <f:radio name="checkpoint" value="false" checked="${instance.checkpoint == false}" id="checkpoint.false"/>
+            <st:nbsp/>${%No}
+        </f:entry>
     </f:advanced>
 
     <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="master,nativeLibraryPath"/>


### PR DESCRIPTION
Adding the checkpointing boolean flag as a new cloud config parameter and setting the default values for fields in config.jelly which can be overridden by users. Also bumping up the org.apache.mesos version number in pom.xml from 0.13.0 to the latest stable 0.16.0 release.
