### PR TITLE
Bug fixes for protobuf compatibility and null pointer exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
       <dependency>
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
-          <version>2.4.1</version>
+          <version>2.5.0</version>
       </dependency>
   </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -236,7 +236,7 @@ public class JenkinsScheduler implements Scheduler {
           "\nRequested for Jenkins slave:\n" +
           "  cpus: " + requestedCpus + "\n" +
           "  mem:  " + requestedMem + "\n" +
-          "  attributes:  " + getMesosCloud().getSlaveAttributes().toString());
+          "  attributes:  " + (getMesosCloud().getSlaveAttributes() == null ? ""  : getMesosCloud().getSlaveAttributes().toString()));
       return false;
     }
   }


### PR DESCRIPTION
Setting the Mesos version back to 0.16.0 for cross-compatibility with protobuf 2.4.1. Also adding a null pointer check before logging the slave attributes.
