### PR TITLE
Made Jenkins a short lived framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ deploy.sh
 # Where Maven generates its output.
 */target/*
 */build/*
+/bin

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -16,6 +16,8 @@
 package org.jenkinsci.plugins.mesos;
 
 
+import hudson.model.Node;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -23,8 +25,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+
 import org.apache.mesos.MesosSchedulerDriver;
 import org.apache.mesos.Protos.Attribute;
 import org.apache.mesos.Protos.CommandInfo;
@@ -59,10 +66,12 @@ public class JenkinsScheduler implements Scheduler {
   private volatile MesosSchedulerDriver driver;
   private final String jenkinsMaster;
   private volatile MesosCloud mesosCloud;
-
+  
   private static final Logger LOGGER = Logger.getLogger(JenkinsScheduler.class.getName());
 
-  public JenkinsScheduler(String jenkinsMaster, MesosCloud mesosCloud) {
+  public static final Lock SUPERVISOR_LOCK = new ReentrantLock();
+  
+  public JenkinsScheduler(String jenkinsMaster, MesosCloud mesosCloud) {  
     LOGGER.info("JenkinsScheduler instantiated with jenkins " + jenkinsMaster +" and mesos " + mesosCloud.getMaster());
 
     this.jenkinsMaster = jenkinsMaster;
@@ -345,7 +354,7 @@ public class JenkinsScheduler implements Scheduler {
     }
 
     Result result = results.get(taskId);
-
+    
     switch (status.getState()) {
     case TASK_STAGING:
     case TASK_STARTING:
@@ -363,6 +372,10 @@ public class JenkinsScheduler implements Scheduler {
       break;
     default:
       throw new IllegalStateException("Invalid State: " + status.getState());
+    }
+    
+    if (mesosCloud.isOnDemandRegistration()) {
+      supervise();
     }
   }
 
@@ -420,6 +433,59 @@ public class JenkinsScheduler implements Scheduler {
     public Request(Mesos.SlaveRequest request, Mesos.SlaveResult result) {
       this.request = request;
       this.result = result;
+    }
+  }
+
+  public int getNumberOfPendingSlaves() {
+    return requests.size();
+  }
+
+  public int getNumberOfActiveTasks() {
+    return results.size();
+  }
+
+  public void clearResults() {
+    results.clear();
+  }
+  
+  /**
+   * Disconnect framework, if we don't have active mesos slaves. Also, make
+   * sure JenkinsScheduler's request queue is empty.
+   */
+  public static void supervise() {
+	SUPERVISOR_LOCK.lock();
+    try {
+      JenkinsScheduler scheduler = (JenkinsScheduler) Mesos.getInstance()
+          .getScheduler();
+      if (scheduler != null) {
+        boolean pendingSlaveRequests = (scheduler.getNumberOfPendingSlaves() > 0);
+        boolean activeSlaves = false;
+        boolean activeTasks = (scheduler.getNumberOfActiveTasks() > 0);
+        List<Node> slaveNodes = Jenkins.getInstance().getNodes();
+        for (Node node : slaveNodes) {
+          if (node instanceof MesosSlave) {
+            activeSlaves = true;
+            break;
+          }
+        }
+        // If there are no active slaves, we should clear up results.
+        if (!activeSlaves) {
+          scheduler.clearResults();
+          activeTasks = false;
+        }
+        LOGGER.info("Active slaves: " + activeSlaves
+            + " | Pending slaves: " + pendingSlaveRequests + " | Active tasks: " + activeTasks);
+        if (!activeTasks && !activeSlaves && !pendingSlaveRequests) {
+          LOGGER.info("No active tasks, or slaves or pending slave requests. Stopping the scheduler.");
+          Mesos.getInstance().stopScheduler();
+        }
+      } else {
+        LOGGER.info("Schedular already stopped. NOOP.");
+      }
+    } catch (Exception e) {
+      LOGGER.info("Exception: " + e);
+    } finally {
+      SUPERVISOR_LOCK.unlock();
     }
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
@@ -14,7 +14,7 @@
  */
 package org.jenkinsci.plugins.mesos;
 
-import hudson.model.Label;
+import org.apache.mesos.Scheduler;
 
 public abstract class Mesos {
   private static MesosImpl mesos;
@@ -55,7 +55,7 @@ public abstract class Mesos {
   abstract public void updateScheduler(MesosCloud mesosCloud);
   abstract public boolean isSchedulerRunning();
   abstract public void stopScheduler();
-
+  abstract public Scheduler getScheduler();
   /**
    * Starts a jenkins slave asynchronously in the mesos cluster.
    *
@@ -127,5 +127,10 @@ public abstract class Mesos {
     }
 
     private JenkinsScheduler scheduler;
+
+    @Override
+    public Scheduler getScheduler() {
+      return scheduler;
+    }
   }
 }

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -66,6 +66,13 @@
             <f:radio name="checkpoint" value="false" checked="${instance.checkpoint == false}" id="checkpoint.false"/>
             <st:nbsp/>${%No}
         </f:entry>
+        
+        <f:entry title="${%On-demand framework registration}" description="${%Enable to make this cloud register as a framework when builds need to be performed. And, disconnect otherwise.}">
+            <f:radio name="onDemandRegistration" value="true" checked="${instance.onDemandRegistration == true}" id="onDemandRegistration.true"/>
+            <st:nbsp/>${%Yes}
+            <f:radio name="onDemandRegistration" value="false" checked="${instance.onDemandRegistration == false}" id="onDemandRegistration.false"/>
+            <st:nbsp/>${%No}
+        </f:entry>
     </f:advanced>
 
     <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="master,nativeLibraryPath"/>


### PR DESCRIPTION
Jenkins master is now made a short lived framework, which is only connected to mesos, when there are pending builds to be processed using mesos cloud plugin. Otherwise, it disconnects and be a good citizen, so that it doesn't affect offer allocation for other connected frameworks.
