### PR TITLE
Fix for https://github.com/jenkinsci/mesos-plugin/issues/10

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -15,6 +15,7 @@
 package org.jenkinsci.plugins.mesos;
 
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.model.Computer;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Hudson;
@@ -110,5 +111,23 @@ public class MesosSlave extends Slave {
   @Override
   public Computer createComputer() {
     return new MesosComputer(this);
+  }
+
+  @Override
+  public FilePath getRootPath() {
+    FilePath rootPath = createPath(remoteFS);
+    if (rootPath != null) {
+      try {
+        // Construct absolute path for slave's remote file system root.
+        rootPath = rootPath.absolutize();
+      } catch (IOException e) {
+        LOGGER.warning("IO exception while absolutizing slave root path: " +e);
+      } catch (InterruptedException e) {
+        LOGGER.warning("InterruptedException while absolutizing slave root path: " +e);
+      }
+    }
+    // Return root path even if we caught an exception,
+    // let the caller handle the error.
+    return rootPath;
   }
 }


### PR DESCRIPTION
Return absolute path instead of relative path for slave file system root. - This enables Maven type jobs(MavenModuleSet) to run on Jenkins slave provisioned by Mesos.
