### PR TITLE
Use 0.18 version of mesos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
       <dependency>
           <groupId>org.apache.mesos</groupId>
           <artifactId>mesos</artifactId>
-          <version>0.17.0</version>
+          <version>0.18.0</version>
       </dependency>
       <dependency>
           <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Update to use version 0.18 of the Mesos library.
