### PR TITLE
Prevent possible NPE with closing Mesos driver.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -102,7 +102,11 @@ public class JenkinsScheduler implements Scheduler {
   }
 
   public synchronized void stop() {
-    driver.stop();
+    if (driver != null) {
+      driver.stop();
+    } else {
+	  LOGGER.warning("Unable to stop Mesos driver:  driver is null.");
+    }
   }
 
   public synchronized boolean isRunning() {


### PR DESCRIPTION
Add conditional check around Mesos driver prior to closing to avoid a NPE.
