### PR TITLE
Added support for setting the agent JVM args.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -52,8 +52,7 @@ public class JenkinsScheduler implements Scheduler {
   private static final double JVM_MEM_OVERHEAD_FACTOR = 0.1;
 
   private static final String SLAVE_COMMAND_FORMAT =
-      "java -DHUDSON_HOME=jenkins -server -Xmx%dm -Xms16m -XX:+UseConcMarkSweepGC " +
-      "-Djava.net.preferIPv4Stack=true -jar slave.jar  -jnlpUrl %s";
+      "java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar slave.jar  -jnlpUrl %s";
 
   private Queue<Request> requests;
   private Map<TaskID, Result> results;
@@ -63,7 +62,7 @@ public class JenkinsScheduler implements Scheduler {
 
   private static final Logger LOGGER = Logger.getLogger(JenkinsScheduler.class.getName());
 
-  public JenkinsScheduler(String jenkinsMaster, MesosCloud mesosCloud) {  
+  public JenkinsScheduler(String jenkinsMaster, MesosCloud mesosCloud) {
     LOGGER.info("JenkinsScheduler instantiated with jenkins " + jenkinsMaster +" and mesos " + mesosCloud.getMaster());
 
     this.jenkinsMaster = jenkinsMaster;
@@ -227,7 +226,7 @@ public class JenkinsScheduler implements Scheduler {
     double requestedMem = (1 + JVM_MEM_OVERHEAD_FACTOR) * request.request.mem;
     // Get matching slave attribute for this label.
     JSONObject slaveAttributes = getMesosCloud().getSlaveAttributeForLabel(request.request.label);
-    
+
     if (requestedCpus <= cpus && requestedMem <= mem && slaveAttributesMatch(offer, slaveAttributes)) {
       return true;
     } else {
@@ -312,7 +311,7 @@ public class JenkinsScheduler implements Scheduler {
             CommandInfo
                 .newBuilder()
                 .setValue(
-                    String.format(SLAVE_COMMAND_FORMAT, request.request.mem,
+                    String.format(SLAVE_COMMAND_FORMAT, request.request.mem, request.request.jvmArgs,
                         getJnlpUrl(request.request.slave.name)))
                 .addUris(
                     CommandInfo.URI.newBuilder().setValue(

--- a/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
@@ -32,12 +32,14 @@ public abstract class Mesos {
     final double cpus;
     final int mem;
     final String label;
+    final String jvmArgs;
 
-    public SlaveRequest(JenkinsSlave slave, double cpus, int mem, String label) {
+    public SlaveRequest(JenkinsSlave slave, double cpus, int mem, String label, String jvmArgs) {
       this.slave = slave;
       this.cpus = cpus;
       this.mem = mem;
       this.label = label;
+      this.jvmArgs = jvmArgs;
     }
   }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -54,7 +54,7 @@ import org.kohsuke.stapler.StaplerRequest;
 
 public class MesosCloud extends Cloud {
   private static final String DEFAULT_FRAMEWORK_NAME = "Jenkins Framework";
-  
+
   private String nativeLibraryPath;
   private String master;
   private String description;
@@ -85,15 +85,15 @@ public class MesosCloud extends Cloud {
     // Turning the AUTOMATIC_SLAVE_LAUNCH flag off because the below slave removals
     // causes computer launch in other slaves that have not been removed yet.
     // To study how a slave removal updates the entire list, one can refer to
-    // Hudson NodeProvisioner class and follow this method chain removeNode() -> 
-    // setNodes() -> updateComputerList() -> updateComputer(). 
+    // Hudson NodeProvisioner class and follow this method chain removeNode() ->
+    // setNodes() -> updateComputerList() -> updateComputer().
     h.AUTOMATIC_SLAVE_LAUNCH = false;
     for (Node n : slaves) {
       //Remove all slaves that were persisted when Jenkins shutdown.
       if (n instanceof MesosSlave) {
         ((MesosSlave)n).terminate();
       }
-    }        
+    }
 
     // Turn it back on for future real slaves.
     h.AUTOMATIC_SLAVE_LAUNCH = true;
@@ -104,7 +104,7 @@ public class MesosCloud extends Cloud {
       }
     }
 
-  } 
+  }
 
   @DataBoundConstructor
   public MesosCloud(String nativeLibraryPath, String master,
@@ -130,12 +130,12 @@ public class MesosCloud extends Cloud {
       // First, we attempt to load the library from the given path.
       // If unsuccessful, we attempt to load using 'MesosNativeLibrary.load()'.
       try {
-      	MesosNativeLibrary.load(nativeLibraryPath);
+          MesosNativeLibrary.load(nativeLibraryPath);
       } catch (UnsatisfiedLinkError error) {
-      	LOGGER.warning("Failed to load native Mesos library from '" + nativeLibraryPath +
-        	             "': " + error.getMessage());
-      	MesosNativeLibrary.load();
-      }	
+          LOGGER.warning("Failed to load native Mesos library from '" + nativeLibraryPath +
+                         "': " + error.getMessage());
+          MesosNativeLibrary.load();
+      }
       nativeLibraryLoaded = true;
     }
 
@@ -198,7 +198,8 @@ public class MesosCloud extends Cloud {
         slaveInfo.getSlaveMem(),
         slaveInfo.getExecutorCpus(),
         slaveInfo.getExecutorMem(),
-        slaveInfo.getIdleTerminationMinutes());
+        slaveInfo.getIdleTerminationMinutes(),
+        slaveInfo.getJvmArgs());
   }
 
   public List<MesosSlaveInfo> getSlaveInfos() {
@@ -339,7 +340,8 @@ public class MesosCloud extends Cloud {
                 object.getString("executorCpus"),
                 object.getString("executorMem"),
                 object.getString("idleTerminationMinutes"),
-                object.getString("slaveAttributes"));
+                object.getString("slaveAttributes"),
+                object.getString("jvmArgs"));
             slaveInfos.add(slaveInfo);
           }
         }
@@ -392,19 +394,19 @@ public class MesosCloud extends Cloud {
         return FormValidation.error(e.getMessage());
       }
     }
-    
+
     public FormValidation doCheckSlaveCpus(@QueryParameter String value) {
-      return doCheckCpus(value);    
+      return doCheckCpus(value);
     }
 
     public FormValidation doCheckExecutorCpus(@QueryParameter String value) {
       return doCheckCpus(value);
     }
-    
+
     private FormValidation doCheckCpus(@QueryParameter String value) {
       boolean valid = true;
       String errorMessage = "Invalid CPUs value, it should be a positive decimal.";
-      
+
       if (StringUtils.isBlank(value)) {
         valid = false;
       } else {
@@ -416,8 +418,8 @@ public class MesosCloud extends Cloud {
           valid = false;
         }
       }
-      
-      return valid ? FormValidation.ok() : FormValidation.error(errorMessage); 
+
+      return valid ? FormValidation.ok() : FormValidation.error(errorMessage);
     }
   }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
@@ -32,6 +32,10 @@ public class MesosComputer extends SlaveComputer {
     return (MesosSlave) super.getNode();
   }
 
+  public String getJvmArgs() {
+      return ((MesosSlave) super.getNode()).getJvmArgs();
+  }
+
   @Override
   public HttpResponse doDoDelete() throws IOException {
     checkPermission(DELETE);

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
@@ -72,7 +72,7 @@ public class MesosComputerLauncher extends ComputerLauncher {
     double cpus = computer.getNode().getCpus();
     int mem = computer.getNode().getMem();
     Mesos.SlaveRequest request = new Mesos.SlaveRequest(new JenkinsSlave(name),
-        cpus, mem, _computer.getNode().getLabelString());
+        cpus, mem, _computer.getNode().getLabelString(), computer.getJvmArgs());
 
     // Launch the jenkins slave.
     final Lock lock = new ReentrantLock();

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -34,6 +34,7 @@ public class MesosSlave extends Slave {
 
   private final double cpus;
   private final int mem;
+  private final String jvmArgs;
 
   private static final Logger LOGGER = Logger.getLogger(MesosSlave.class
       .getName());
@@ -41,7 +42,7 @@ public class MesosSlave extends Slave {
   @DataBoundConstructor
   public MesosSlave(String name, int numExecutors, String labelString,
       double slaveCpus, int slaveMem, double executorCpus, int executorMem,
-      int idleTerminationMinutes) throws FormException, IOException
+      int idleTerminationMinutes, String jvmArgs) throws FormException, IOException
   {
     super(name,
           labelString, // node description.
@@ -55,6 +56,7 @@ public class MesosSlave extends Slave {
 
     this.cpus = slaveCpus + (numExecutors * executorCpus);
     this.mem = slaveMem + (numExecutors * executorMem);
+    this.jvmArgs = jvmArgs;
 
     LOGGER.info("Constructing Mesos slave");
   }
@@ -65,6 +67,10 @@ public class MesosSlave extends Slave {
 
   public int getMem() {
     return mem;
+  }
+
+  public String getJvmArgs() {
+      return jvmArgs;
   }
 
   public void terminate() {

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -10,52 +10,55 @@
     <f:entry title="${%Description}">
         <f:textbox field="description" />
     </f:entry>
-    
+
     <f:entry title="${%Framework Name}">
         <f:textbox field="frameworkName" default="Jenkins Scheduler" />
     </f:entry>
 
     <f:advanced>
-		<f:entry>
-		    <f:repeatable add="${%Add Slave Info}" var="slaveInfo" name="slaveInfos" items="${instance.slaveInfos}" noAddButton="false" minimum="1" >
-		        <table width="100%">
-		        <f:entry title="${%Label String}">
-					<f:textbox field="labelString" default="mesos" value="${slaveInfo.labelString}" />
-		    	</f:entry>
-		        <f:entry title="${%Jenkins Slave CPUs}">
-		            <f:textbox field="slaveCpus" clazz="required" default="0.1" value="${slaveInfo.slaveCpus}" />
-		        </f:entry>
-		
-		        <f:entry title="${%Jenkins Slave Memory in MB}">
-		            <f:number field="slaveMem" clazz="required positive-number" default="512" value="${slaveInfo.slaveMem}"/>
-		        </f:entry>
-		
-		        <f:entry title="${% Maximum number of Executors per Slave}">
-		            <f:number field="maxExecutors" clazz="required number" default="2" value="${slaveInfo.maxExecutors}"/>
-		        </f:entry>
-		
-		        <f:entry title="${%Jenkins Executor CPUs}">
-		            <f:textbox field="executorCpus" clazz="required" default="0.1" value="${slaveInfo.executorCpus}"/>
-		        </f:entry>
-		
-		        <f:entry title="${%Jenkins Executor Memory in MB}">
-		            <f:number field="executorMem" clazz="required positive-number" default="128" value="${slaveInfo.executorMem}"/>
-		        </f:entry>
-		
-		        <f:entry title="${%Idle Termination Minutes}">
-		            <f:number field="idleTerminationMinutes" clazz="required positive-number" default="3" value="${slaveInfo.idleTerminationMinutes}"/>
-		        </f:entry>
-				<f:entry title="${%Mesos Offer Selection Attributes}">
-					<f:textbox field="slaveAttributes" value="${slaveInfo.slaveAttributes}"/>
-				</f:entry>
-		        <f:entry>
-			          <div align="right" class="repeatable-delete show-if-only" style="margin-left: 1em;">
-			            <f:repeatableDeleteButton value="${%Delete Slave Info}" /><br/>
-			          </div>
-		        </f:entry>
-		        </table>
-		     </f:repeatable>
-	   </f:entry>
+        <f:entry>
+            <f:repeatable add="${%Add Slave Info}" var="slaveInfo" name="slaveInfos" items="${instance.slaveInfos}" noAddButton="false" minimum="1" >
+                <table width="100%">
+                    <f:entry title="${%Label String}">
+                        <f:textbox field="labelString" default="mesos" value="${slaveInfo.labelString}" />
+                    </f:entry>
+                    <f:entry title="${%Jenkins Slave CPUs}">
+                        <f:textbox field="slaveCpus" clazz="required" default="0.1" value="${slaveInfo.slaveCpus}" />
+                    </f:entry>
+
+                    <f:entry title="${%Jenkins Slave Memory in MB}">
+                        <f:number field="slaveMem" clazz="required positive-number" default="512" value="${slaveInfo.slaveMem}"/>
+                    </f:entry>
+
+                    <f:entry title="${% Maximum number of Executors per Slave}">
+                        <f:number field="maxExecutors" clazz="required number" default="2" value="${slaveInfo.maxExecutors}"/>
+                    </f:entry>
+
+                    <f:entry title="${%Jenkins Executor CPUs}">
+                        <f:textbox field="executorCpus" clazz="required" default="0.1" value="${slaveInfo.executorCpus}"/>
+                    </f:entry>
+
+                    <f:entry title="${%Jenkins Executor Memory in MB}">
+                        <f:number field="executorMem" clazz="required positive-number" default="128" value="${slaveInfo.executorMem}"/>
+                    </f:entry>
+
+                    <f:entry title="${%Idle Termination Minutes}">
+                        <f:number field="idleTerminationMinutes" clazz="required positive-number" default="3" value="${slaveInfo.idleTerminationMinutes}"/>
+                    </f:entry>
+                    <f:entry title="${%Mesos Offer Selection Attributes}">
+                        <f:textbox field="slaveAttributes" value="${slaveInfo.slaveAttributes}"/>
+                    </f:entry>
+                    <f:entry title="${%Additional Jekins Slave Agent JVM arguments}">
+                        <f:textbox field="jvmArgs" default="-Xms16m -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true" value="${slaveInfo.jvmArgs}"/>
+                    </f:entry>
+                    <f:entry>
+                          <div align="right" class="repeatable-delete show-if-only" style="margin-left: 1em;">
+                            <f:repeatableDeleteButton value="${%Delete Slave Info}" /><br/>
+                          </div>
+                    </f:entry>
+                </table>
+             </f:repeatable>
+       </f:entry>
 
         <f:entry title="${%Slave Checkpointing}" description="${%Enable Mesos slave checkpointing?}">
             <f:radio name="checkpoint" value="true" checked="${instance.checkpoint == true}" id="checkpoint.true"/>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-jvmArgs.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-jvmArgs.html
@@ -1,0 +1,3 @@
+<div>
+    Specifies the additional JVM arguments to be used when invoking the Jenkins slave agent on the Mesos slave.  <b>NOTE:</b> Any references to the "Xmx" JVM argument will be removed so that the maximum heap size available to the slave will be set dynamically based on the available memory.  The available memory is derived from the following calculation:  Jenkins Slave Memory in MB + (Maximum number of Executors per Slave * Jenkins Executor Memory in MB).
+</div>


### PR DESCRIPTION
Expose the Jenkins agent JVM arguments via the Jelly-based configuration.  This change also prevents the overriding of the `-Xmx` setting.
