### PR TITLE
mark uri as not executable and not extractable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -319,7 +319,7 @@ public class JenkinsScheduler implements Scheduler {
                         getJnlpUrl(request.request.slave.name)))
                 .addUris(
                     CommandInfo.URI.newBuilder().setValue(
-                        joinPaths(jenkinsMaster, SLAVE_JAR_URI_SUFFIX)))).build();
+                        joinPaths(jenkinsMaster, SLAVE_JAR_URI_SUFFIX)).setExecutable(false).setExtract(false))).build();
 
     List<TaskInfo> tasks = new ArrayList<TaskInfo>();
     tasks.add(task);


### PR DESCRIPTION
The logic behind executing and extracting the URI has changed between:
- Mesos 0.17 - [only extract if the file extension matches a whitelist](https://github.com/apache/mesos/blob/0.17.0/src/launcher/launcher.cpp#L335)
- Mesos 0.18 - [extract if not marked executable](https://github.com/apache/mesos/blob/0.18.0/src/launcher/fetcher.cpp#L216)

When using the plugin with Mesos 0.18, the slave jar uri **must** be marked as executable or else Mesos will attempt to extract it and fail because `.jar` is an [unrecognized extension](https://github.com/apache/mesos/blob/0.18.0/src/launcher/fetcher.cpp#L51).

Without this patch:

```
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0504 17:51:28.462967 18682 fetcher.cpp:73] Fetching URI 'http://localhost:5555/jnlpJars/slave.jar'
I0504 17:51:28.462976 18682 fetcher.cpp:120] Downloading 'http://localhost:5555/jnlpJars/slave.jar' to '/tmp/mesos/slaves/20140502-114426-16777343-5050-19596-0/frameworks/20140502-131719-16777343-5050-23692-0002/executors/mesos-jenkins-c5e264f3-4c63-48ad-b681-420726993b78/runs/3882e507-1a29-4c07-8cee-788be235468e/slave.jar'
Failed to extract /tmp/mesos/slaves/20140502-114426-16777343-5050-19596-0/frameworks/20140502-131719-16777343-5050-23692-0002/executors/mesos-jenkins-c5e264f3-4c63-48ad-b681-420726993b78/runs/3882e507-1a29-4c07-8cee-788be235468e/slave.jar:Could not extract file with unrecognized extension
```

With this patch:

```
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0504 18:03:19.633577 20720 fetcher.cpp:73] Fetching URI 'http://localhost:5555/jnlpJars/slave.jar'
I0504 18:03:19.633586 20720 fetcher.cpp:120] Downloading 'http://localhost:5555/jnlpJars/slave.jar' to '/tmp/mesos/slaves/20140504-175946-16777343-5050-19989-0/frameworks/20140504-175946-16777343-5050-19989-0000/executors/mesos-jenkins-53a2ad08-fbcb-4573-a9e7-a0557eb3aac2/runs/16fab6e0-4632-43c4-824b-ce3f54a29b72/slave.jar'
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0504 18:03:19.801707 20750 exec.cpp:131] Version: 0.18.0
I0504 18:03:19.840648 20770 exec.cpp:205] Executor registered on slave 20140504-175946-16777343-5050-19989-0
May 04, 2014 6:03:20 PM hudson.remoting.jnlp.Main createEngine
INFO: Setting up slave: mesos-jenkins-53a2ad08-fbcb-4573-a9e7-a0557eb3aac2
May 04, 2014 6:03:20 PM hudson.remoting.jnlp.Main$CuiListener <init>
INFO: Jenkins agent is running in headless mode.
May 04, 2014 6:03:20 PM hudson.remoting.jnlp.Main$CuiListener status
INFO: Locating server among [http://localhost:5555/]
May 04, 2014 6:03:20 PM hudson.remoting.jnlp.Main$CuiListener status
INFO: Connecting to localhost:55266
May 04, 2014 6:03:20 PM hudson.remoting.jnlp.Main$CuiListener status
INFO: Handshaking
May 04, 2014 6:03:20 PM hudson.remoting.jnlp.Main$CuiListener status
INFO: Connected
```
