### PR TITLE
If a slave is in terminal state do not consider it active

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -167,6 +167,10 @@ public class JenkinsScheduler implements Scheduler {
         LOGGER.warning("Asked to kill unknown mesos task " + taskId);
     }
 
+    if (mesosCloud.isOnDemandRegistration()) {
+      supervise();
+    }
+
   }
 
   @Override
@@ -443,7 +447,7 @@ public class JenkinsScheduler implements Scheduler {
     }
   }
 
-  public int getNumberOfPendingSlaves() {
+  public int getNumberofPendingTasks() {
     return requests.size();
   }
 
@@ -465,7 +469,7 @@ public class JenkinsScheduler implements Scheduler {
       JenkinsScheduler scheduler = (JenkinsScheduler) Mesos.getInstance()
           .getScheduler();
       if (scheduler != null) {
-        boolean pendingSlaveRequests = (scheduler.getNumberOfPendingSlaves() > 0);
+        boolean pendingTasks = (scheduler.getNumberofPendingTasks() > 0);
         boolean activeSlaves = false;
         boolean activeTasks = (scheduler.getNumberOfActiveTasks() > 0);
         List<Node> slaveNodes = Jenkins.getInstance().getNodes();
@@ -481,8 +485,8 @@ public class JenkinsScheduler implements Scheduler {
           activeTasks = false;
         }
         LOGGER.info("Active slaves: " + activeSlaves
-            + " | Pending slaves: " + pendingSlaveRequests + " | Active tasks: " + activeTasks);
-        if (!activeTasks && !activeSlaves && !pendingSlaveRequests) {
+            + " | Pending tasks: " + pendingTasks + " | Active tasks: " + activeTasks);
+        if (!activeTasks && !activeSlaves && !pendingTasks) {
           LOGGER.info("No active tasks, or slaves or pending slave requests. Stopping the scheduler.");
           Mesos.getInstance().stopScheduler();
         }


### PR DESCRIPTION
This fix is for on demand registration feature. Sometimes the Mesos spawned Jenkins slave goes into TASK_LOST state after the build is complete. On this event, supervise() method will  get called but the node will still be in Jenkins. So in this case supervise() would not disconnect Jenkins from Mesos cloud at all. This change makes sure the slave is marked as active only if it is not in terminal state.
