### PR TITLE
Mesos 0.19.0 container support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Login to the Mesos master's Web UI to verify that the plugin is registered as
 
 ### Mesos slave setup ###
 
-Ensure Mesos slaves have a `jenkins` user or the user the Jenkins master is running as.
+Ensure Mesos slaves have a `jenkins` user or the user the Jenkins master is running as. `jenkins` user should have JAVA_HOME environment variable setup.
 
 ### Adding Slave Info ###
 
@@ -106,6 +106,10 @@ master to finish running its slave jobs even if the Mesos slave process temporar
 
 Finally, just add the label name you have configured in Mesos cloud configuration -> Advanced -> Slave Info -> Label String (default is `mesos`) 
 to the jobs (configure -> Restrict where this project can run checkbox) that you want to run on a specific slave type inside Mesos cluster.
+
+### Optional container image
+
+Supported >= Mesos 0.19.0. Leave this field empty if you want Jenkins worker run normally without container (mesos-slave shouldn't be configured for Containerization either). When Mesos slave is configured with containerizer_path and isolation, this option will pull container images and launch Jenkins worker inside container. You will need protocol prefix; for Docker this would be `docker:///username/container-name`. Take a look at [jenkins-dind](https://github.com/ahunnargikar/jenkins-dind) for an example Docker image; you can decide which strategy, single or docker-in-docker, is suitable.   
 
 Thats it!
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
       <dependency>
           <groupId>org.apache.mesos</groupId>
           <artifactId>mesos</artifactId>
-          <version>0.18.1</version>
+          <version>0.19.0</version>
       </dependency>
       <dependency>
           <groupId>com.google.protobuf</groupId>

--- a/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
@@ -33,15 +33,29 @@ public abstract class Mesos {
     final int mem;
     final String label;
     final String jvmArgs;
+    final String containerImage;
+    final String containerOptions;
 
-    public SlaveRequest(JenkinsSlave slave, double cpus, int mem, String label, String jvmArgs) {
+    public SlaveRequest(JenkinsSlave slave, double cpus, int mem, String label,
+                        String jvmArgs, String containerImage, String containerOptions) {
       this.slave = slave;
       this.cpus = cpus;
       this.mem = mem;
       this.label = label;
       this.jvmArgs = jvmArgs;
+      this.containerImage = containerImage.trim();
+      this.containerOptions = containerOptions.trim();
+    }
+
+    public String[] getContainerOptions() {
+      if (this.containerOptions.trim().isEmpty()) {
+        return new String[0];
+      } else {
+        return this.containerOptions.trim().split(",");
+      }
     }
   }
+
 
   interface SlaveResult {
     void running(JenkinsSlave slave);
@@ -132,5 +146,6 @@ public abstract class Mesos {
     public Scheduler getScheduler() {
       return scheduler;
     }
+
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -59,7 +59,7 @@ public class MesosCloud extends Cloud {
   private String frameworkName;
   private final boolean checkpoint; // Set true to enable Mesos slave checkpoints. False by default.
   private boolean onDemandRegistration; // If set true, this framework disconnects when there are no builds in the queue and re-registers when there are.
-  
+
   // Find the default values for these variables in
   // src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly.
   private List<MesosSlaveInfo> slaveInfos;
@@ -121,7 +121,7 @@ public class MesosCloud extends Cloud {
     this.slaveInfos = slaveInfos;
     this.checkpoint = checkpoint;
     this.onDemandRegistration = onDemandRegistration;
-    
+
     JenkinsScheduler.SUPERVISOR_LOCK.lock();
     try {
       restartMesos();
@@ -217,7 +217,9 @@ public class MesosCloud extends Cloud {
         slaveInfo.getExecutorCpus(),
         slaveInfo.getExecutorMem(),
         slaveInfo.getIdleTerminationMinutes(),
-        slaveInfo.getJvmArgs());
+        slaveInfo.getJvmArgs(),
+        slaveInfo.getContainerImage(),
+        slaveInfo.getContainerOptions());
   }
 
   public List<MesosSlaveInfo> getSlaveInfos() {
@@ -367,7 +369,9 @@ public class MesosCloud extends Cloud {
                 object.getString("executorMem"),
                 object.getString("idleTerminationMinutes"),
                 object.getString("slaveAttributes"),
-                object.getString("jvmArgs"));
+                object.getString("jvmArgs"),
+                object.getString("containerImage"),
+                object.getString("containerOptions"));
             slaveInfos.add(slaveInfo);
           }
         }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
@@ -71,8 +71,12 @@ public class MesosComputerLauncher extends ComputerLauncher {
     // Create the request.
     double cpus = computer.getNode().getCpus();
     int mem = computer.getNode().getMem();
+    String containerImage = computer.getNode().getContainerImage();
+    String containerOptions = computer.getNode().getContainerOptions();
+
     Mesos.SlaveRequest request = new Mesos.SlaveRequest(new JenkinsSlave(name),
-        cpus, mem, _computer.getNode().getLabelString(), computer.getJvmArgs());
+        cpus, mem, _computer.getNode().getLabelString(), computer.getJvmArgs(),
+        containerImage, containerOptions);
 
     // Launch the jenkins slave.
     final Lock lock = new ReentrantLock();

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -35,6 +35,8 @@ public class MesosSlave extends Slave {
   private final double cpus;
   private final int mem;
   private final String jvmArgs;
+  private final String containerImage;
+  private final String containerOptions;
 
   private static final Logger LOGGER = Logger.getLogger(MesosSlave.class
       .getName());
@@ -42,7 +44,7 @@ public class MesosSlave extends Slave {
   @DataBoundConstructor
   public MesosSlave(String name, int numExecutors, String labelString,
       double slaveCpus, int slaveMem, double executorCpus, int executorMem,
-      int idleTerminationMinutes, String jvmArgs) throws FormException, IOException
+      int idleTerminationMinutes, String jvmArgs, String containerImage, String containerOptions) throws FormException, IOException
   {
     super(name,
           labelString, // node description.
@@ -57,6 +59,8 @@ public class MesosSlave extends Slave {
     this.cpus = slaveCpus + (numExecutors * executorCpus);
     this.mem = slaveMem + (numExecutors * executorMem);
     this.jvmArgs = jvmArgs;
+    this.containerImage = containerImage;
+    this.containerOptions = containerOptions;
 
     LOGGER.info("Constructing Mesos slave");
   }
@@ -70,7 +74,15 @@ public class MesosSlave extends Slave {
   }
 
   public String getJvmArgs() {
-      return jvmArgs;
+    return jvmArgs;
+  }
+
+  public String getContainerImage() {
+    return containerImage;
+  }
+
+  public String getContainerOptions() {
+    return containerOptions;
   }
 
   public void terminate() {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -21,6 +21,8 @@ public class MesosSlaveInfo {
   private final int idleTerminationMinutes;
   private final String jvmArgs;
   private final JSONObject slaveAttributes; // Slave attributes JSON representation.
+  private final String containerImage;
+  private final String containerOptions;
 
   private String labelString = DEFAULT_LABEL_NAME;
 
@@ -29,7 +31,8 @@ public class MesosSlaveInfo {
   @DataBoundConstructor
   public MesosSlaveInfo(String labelString, String slaveCpus, String slaveMem,
       String maxExecutors, String executorCpus, String executorMem,
-      String idleTerminationMinutes, String slaveAttributes, String jvmArgs) throws NumberFormatException {
+      String idleTerminationMinutes, String slaveAttributes, String jvmArgs,
+      String containerImage, String containerOptions) throws NumberFormatException {
     this.slaveCpus = Double.parseDouble(slaveCpus);
     this.slaveMem = Integer.parseInt(slaveMem);
     this.maxExecutors = Integer.parseInt(maxExecutors);
@@ -40,6 +43,8 @@ public class MesosSlaveInfo {
         : DEFAULT_LABEL_NAME;
     this.jvmArgs = StringUtils.isNotBlank(jvmArgs) ? cleanseJvmArgs(jvmArgs)
         : DEFAULT_JVM_ARGS;
+    this.containerImage = containerImage;
+    this.containerOptions = containerOptions;
 
     // Parse the attributes provided from the cloud config
     JSONObject jsonObject = null;
@@ -91,6 +96,13 @@ public class MesosSlaveInfo {
     return jvmArgs;
   }
 
+  public String getContainerImage() {
+    return containerImage;
+  }
+
+  public String getContainerOptions() {
+    return containerOptions;
+  }
   /**
    * Removes any additional {@code -Xmx} JVM args from the
    * provided JVM arguments.  This is to ensure that the logic

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -51,10 +51,19 @@
                     <f:entry title="${%Additional Jenkins Slave Agent JVM arguments}" field="jvmArgs">
                         <f:textbox field="jvmArgs" default="-Xms16m -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true" value="${slaveInfo.jvmArgs}"/>
                     </f:entry>
+
+                    <f:entry title="${%Container image}" field="containerImage" description="Leave this empty to execute without containerization. Docker image requires prefix docker:///">
+                        <f:textbox field="containerImage" value="${slaveInfo.containerImage}" default=""/>
+                    </f:entry>
+
+                    <f:entry title="${%Container options}" field="containerOptions" description="Comma separated list of options to pass to the containerizer">
+                        <f:textbox field="containerOptions" value="${slaveInfo.containerOptions}" default=""/>
+                    </f:entry>
+
                     <f:entry>
-                          <div align="right" class="repeatable-delete show-if-only" style="margin-left: 1em;">
-                            <f:repeatableDeleteButton value="${%Delete Slave Info}" /><br/>
-                          </div>
+                        <div align="right" class="repeatable-delete show-if-only" style="margin-left: 1em;">
+                          <f:repeatableDeleteButton value="${%Delete Slave Info}" /><br/>
+                        </div>
                     </f:entry>
                 </table>
              </f:repeatable>


### PR DESCRIPTION
Together with @tarnfeld 's initial effort, I patched and improved the container support feature:
- Container input box is persisted correctly
- Each slave configuration can have their own container configuration, this enables option to run dind or single docker image for different build labels/setups
- When container image option is empty, TaskInfo is built without container command
  - if mesos-slave has containerizer_path and isolation setup, it will run the default container
  - otherwise mesos-slave will run normally without containerizer. 

I tested on an AWS setup, it works nicely. 

Update: updated README for container support.

This PR should have addressed #44 and delivered #18
