### PR TITLE
Use the official Ubuntu vagrant image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,11 +74,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "precise64"
+  config.vm.box = "ubuntu/precise64"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
   # Forward mesos ports.
   config.vm.network "forwarded_port", guest: 5050, host: 5050


### PR DESCRIPTION
...to cut down on disk space usage (if people already have this image
downloaded), and use the "official" image.

I believe this is what the Vagrantfile was already doing, and doing correctly;
with the introduction of "vagrantcloud" the semantics just changed a bit.