### PR TITLE
[JENKINS-26236] Add Docker parameter functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ By default, the Jenkins slaves are run in the default Mesos container. To run th
 	1) "Use Native Docker Containerizer" : Select this option if Mesos slave(s) are configured with "--containerizers=docker" (recommended).
 
 	2) "Use External Containerizer" : Select this option if Mesos slave(s) are configured with "--containerizers=external".
+	
+### Docker Configuration ###
+
+#### Volumes ####
+
+At a minimum, a container path must be entered to mount the volume. A host path can also be specified to bind mount the container path to the host path. This will allow persistence of data between slaves on the same node. The default setting is read-write, but an option is provided for read-only use.
+
+#### Parameters ####
+
+Additional parameters are available for the `docker run` command, but there are too many and they change too often to list all separately. This section allows you to provide any parameter you want. Ensure that your Docker version on your Mesos slaves is compatible with the parameters you add and that the values are correctly formatted. Use the full-word parameter and not the shortcut version, as these may not work properly. Also, exclude the preceding double-dash on the parameter name. For example, enter `volumes-from` and `my_container_name` to recieve the volumes from `my_container_name`. Of course `my_container_name` must already be on the Mesos slave where the Jenkins slave will run. This shouldn't cause problems in a homogenous environment where Jenkins slaves only run on particular Mesos slaves.
 
 ### Jenkins master authentication ###
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,13 @@
       <email>vinodkone@gmail.com</email>
     </developer>
   </developers>
+  
+  <contributors>
+    <contributor>
+      <name>Daniel Barker</name>
+      <email>barkerd@dbdevs.com</email>
+    </contributor>
+  </contributors>
 
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
   <repositories>
@@ -73,7 +80,7 @@
       <dependency>
           <groupId>org.apache.mesos</groupId>
           <artifactId>mesos</artifactId>
-          <version>0.20.0</version>
+          <version>0.21.0</version>
       </dependency>
       <dependency>
           <groupId>com.google.protobuf</groupId>

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -25,7 +25,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
@@ -36,7 +35,6 @@ import net.sf.json.JSONObject;
 import com.google.protobuf.ByteString;
 
 import org.apache.commons.lang.StringUtils;
-
 import org.apache.mesos.MesosSchedulerDriver;
 import org.apache.mesos.Protos.Attribute;
 import org.apache.mesos.Protos.CommandInfo;
@@ -50,6 +48,7 @@ import org.apache.mesos.Protos.FrameworkInfo;
 import org.apache.mesos.Protos.MasterInfo;
 import org.apache.mesos.Protos.Offer;
 import org.apache.mesos.Protos.OfferID;
+import org.apache.mesos.Protos.Parameter;
 import org.apache.mesos.Protos.Resource;
 import org.apache.mesos.Protos.SlaveID;
 import org.apache.mesos.Protos.Status;
@@ -395,7 +394,14 @@ public class JenkinsScheduler implements Scheduler {
       switch(containerType) {
         case DOCKER:
           LOGGER.info("Launching in Docker Mode:" + containerInfo.getDockerImage());
-          containerInfoBuilder.setDocker(DockerInfo.newBuilder().setImage(containerInfo.getDockerImage()));
+          DockerInfo.Builder dockerInfoBuilder = DockerInfo.newBuilder();
+          if (containerInfo.getParameters() != null) {
+            for (MesosSlaveInfo.Parameter parameter : containerInfo.getParameters()) {
+              LOGGER.info("Adding Docker parameter '" + parameter.getKey() + ":" + parameter.getValue() + "'");
+              dockerInfoBuilder.addParameters(Parameter.newBuilder().setKey(parameter.getKey()).setValue(parameter.getValue()).build());
+            }
+          }
+          containerInfoBuilder.setDocker(dockerInfoBuilder.setImage(containerInfo.getDockerImage()));
           break;
         default:
           LOGGER.warning("Unknown container type:" + containerInfo.getType());

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -46,6 +46,7 @@ import net.sf.json.JSONObject;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.mesos.MesosNativeLibrary;
+import org.apache.mesos.Protos.Parameter;
 import org.jenkinsci.plugins.mesos.MesosSlaveInfo.URI;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -407,10 +408,20 @@ public class MesosCloud extends Cloud {
                           .getBoolean("readOnly")));
                 }
               }
+              
+              List<MesosSlaveInfo.Parameter> parameters = new ArrayList<MesosSlaveInfo.Parameter>();
+              
+              if (containerInfoJson.has("parameters")) {
+                JSONArray parametersJson = containerInfoJson.getJSONArray("parameters");
+                for (Object obj : parametersJson) {
+                  JSONObject parameterJson = (JSONObject) obj;
+                  parameters.add(new MesosSlaveInfo.Parameter(parameterJson.getString("key"), parameterJson.getString("value")));
+                }
+              }
 
               containerInfo = new MesosSlaveInfo.ContainerInfo(
                   containerInfoJson.getString("type"),
-                  containerInfoJson.getString("dockerImage"), volumes);
+                  containerInfoJson.getString("dockerImage"), volumes, parameters);
             }
 
             List<MesosSlaveInfo.URI> additionalURIs = new ArrayList<MesosSlaveInfo.URI>();

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -10,7 +10,6 @@ import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.mesos.Protos.ContainerInfo;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class MesosSlaveInfo {
@@ -180,13 +179,15 @@ public class MesosSlaveInfo {
     private final String type;
     private final String dockerImage;
     private final List<Volume> volumes;
+    private final List<Parameter> parameters;
 
     @DataBoundConstructor
-    public ContainerInfo(String type, String dockerImage, List<Volume> volumes)
+    public ContainerInfo(String type, String dockerImage, List<Volume> volumes, List<Parameter> parameters)
       throws FormException {
       this.type = type;
       this.dockerImage = dockerImage;
       this.volumes = volumes;
+      this.parameters = parameters;
     }
 
     public String getType() {
@@ -199,6 +200,29 @@ public class MesosSlaveInfo {
 
     public List<Volume> getVolumes() {
       return volumes;
+    }
+    
+    public List<Parameter> getParameters() {
+      return parameters;
+    }
+  }
+  
+  public static class Parameter {
+    private final String key;
+    private final String value;
+      
+    @DataBoundConstructor
+    public Parameter(String key, String value) {
+      this.key = key;
+      this.value = value;
+    }
+    
+    public String getKey() {
+      return key;
+    }
+    
+    public String getValue() {
+      return value;
     }
   }
 

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -123,7 +123,7 @@
                             </f:entry>
                             
                             <f:entry title="${%Parameters}" field="parameters">
-                                <f:repeatable add="${%Parameter}" var="parameter" name="parameters" items="${slaveInfo.containerInfo.parameters}" noAddButton="false" minimum="0">
+                                <f:repeatable add="${%Add Parameter}" var="parameter" name="parameters" items="${slaveInfo.containerInfo.parameters}" noAddButton="false" minimum="0">
                                     <fieldset>
                                         <table width="100%">
                                             <f:entry title="${%Parameter Key}">

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -121,6 +121,29 @@
                                     </fieldset>
                                 </f:repeatable>
                             </f:entry>
+                            
+                            <f:entry title="${%Parameters}" field="parameters">
+                                <f:repeatable add="${%Parameter}" var="parameter" name="parameters" items="${slaveInfo.containerInfo.parameters}" noAddButton="false" minimum="0">
+                                    <fieldset>
+                                        <table width="100%">
+                                            <f:entry title="${%Parameter Key}">
+                                                <f:textbox field="key" clazz="required" default="" value="${parameter.key}" />
+                                            </f:entry>
+                                            
+                                            <f:entry title="${%Parameter Value}">
+                                                <f:textbox field="value" clazz="required" default="" value="${parameter.value}" />
+                                            </f:entry>
+
+                                            <f:entry>
+                                                <div align="right" class="repeatable-delete show-if-only" style="margin-left: 1em;">
+                                                    <f:repeatableDeleteButton value="${%Delete Parameter}" /><br/>
+                                                </div>
+                                            </f:entry>
+
+                                        </table>
+                                    </fieldset>
+                                </f:repeatable>
+                            </f:entry>
                         </f:optionalBlock>
 
                         <f:optionalBlock title="${%Use External Containerizer}" name="externalContainerInfo" checked="${slaveInfo.externalContainerInfo != null}">

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-parameters.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-parameters.html
@@ -1,0 +1,3 @@
+<div>
+  Add Docker parameters like volumes-from without the preceding double-dash "--".
+</div>


### PR DESCRIPTION
This will allow the use of Docker parameters which is available in mesos 0.21.0. This also brings the plugin up-to-date with the latest mesos release. My use-case has been to allow the sharing of data containers among slaves on a particular node. Specifically not requiring tools and maven dependencies to have long download times for each build. There are likely other use-cases that I have yet to explore, but this has been tested in my Jenkins instance.