### PR TITLE
[JENKINS-26324] Add configurable bridged network mode for Docker containers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
               <artifactId>maven-compiler-plugin</artifactId>
               <configuration>
                   <target>1.6</target>
+                  <source>1.6</source>
               </configuration>
           </plugin>
       </plugins>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -103,6 +103,37 @@
                                 </f:radioBlock>
                             </f:entry>
 
+                            <f:entry title="${%Networking}" description="${%Specify the networking mode to use for this container}" field="networking" >
+                                <f:radioBlock id="networking.HOST" name="networking" title="${%Host}" value="HOST" inline="true" checked="${slaveInfo.containerInfo.networking == 'HOST'}" />
+                                <f:radioBlock id="networking.BRIDGE" name="networking" title="${%Bridge}" value="BRIDGE" inline="true" checked="${slaveInfo.containerInfo.networking == null || slaveInfo.containerInfo.networking == 'BRIDGE'}">
+                                    <f:entry title="${%Port Mappings}">
+                                        <f:repeatable add="${%Add Port Mapping}" var="portMapping" name="portMappings" items="${slaveInfo.containerInfo.portMappings}" noAddButton="false" minimum="0">
+                                            <fieldset>
+                                                <table width="100%">
+                                                    <f:entry title="${%Container Port}" field="containerPort">
+                                                        <f:textbox clazz="required positive-number" default="" value="${portMapping.containerPort}" />
+                                                    </f:entry>
+                                                    <f:entry title="${%Host Port}" field="hostPort">
+                                                        <f:textbox clazz="positive-number" default="" value="${portMapping.hostPort}" />
+                                                    </f:entry>
+                                                    <f:entry title="${%Protocol}" field="protocol">
+                                                        <select name="protocol" value="${portMapping.protocol}" class="setting-input select">
+                                                            <f:option value="tcp" selected="${portMapping.protocol == 'tcp'}">tcp</f:option>
+                                                            <f:option value="udp" selected="${portMapping.protocol == 'udp'}">udp</f:option>
+                                                        </select>
+                                                    </f:entry>
+                                                    <f:entry>
+                                                        <div align="right" class="repeatable-delete show-if-only" style="margin-left: 1em;">
+                                                            <f:repeatableDeleteButton value="${%Delete Port Mapping}" /><br/>
+                                                        </div>
+                                                    </f:entry>
+                                                </table>
+                                            </fieldset>
+                                        </f:repeatable>
+                                    </f:entry>
+                                </f:radioBlock>
+                            </f:entry>
+
                             <f:entry title="${%Volumes}">
                                 <f:repeatable add="${%Add Volume}" var="volume" name="volumes" items="${slaveInfo.containerInfo.volumes}" noAddButton="false" minimum="0">
                                     <fieldset>


### PR DESCRIPTION
This pull request adds a new feature described in https://issues.jenkins-ci.org/browse/JENKINS-26324

Changes made:
* ~~Updated Mesos libs to 0.21.0 and HPI plugin to 1.106~~
* HOST and BRIDGE networking for docker containers can now be configured
* Port mappings for those are also possible (if Host Port is left empty, a random Port on the host is used)

~~Snuck in changes (I tried to keep commits atomic, but this happened anyway):~~
* ~~Slave name on Jenkins is now dependent on label (which might not always be good); See: String name = slaveInfo.getLabelString() + "-" + UUID.randomUUID().toString();~~
* ~~The hostname of the docker container is set to the name of the slave~~
* ~~An Exception is now logged if something happens in createMesosTask()~~
* ~~HUDSON_HOME changed from jenkins to /home/jenkins at SLAVE_COMMAND_FORMAT~~

Also: The code for the evaluation of the port range received by the offer is a bit dodgy. I'll try to rewrite this if I got some spare time.