### PR TITLE
Upgraded to build with Mesos 0.21.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,14 @@
 target/
 work/
 
+# Exclude IntelliJ files
+.idea/
+*.iml
+*.ipr
+
+# Exclude Vagrant generated files
+.vagrant/
+
 # Used as a local build/deploy dev-cycle script
 deploy.sh
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This should build the Mesos native library in the `build/src/.libs` folder.
 
 ### Vagrant ###
 
-If you are just looking to play with Mesos and this plugin in a VM, you could do so with the included Vagrantfile.
+If you are just looking to play with Mesos and this plugin in a single self contained VM, you could do so with the included Vagrantfile.
 
 		$ vagrant up
 		$ vagrant ssh
@@ -101,7 +101,7 @@ Mesos slaves based on attributes specified in JSON format. Ex. {"clusterType":"j
 
 By default the plugin (a Mesos framework) registers with Mesos master without authentication. To enable authentication:
 
-  1. Set the `Framework principal` and `Framework Secret` fieds in the plugin configuration page.
+  1. Set the `Framework principal` and `Framework Secret` fields in the plugin configuration page.
 
   2. Ensure the same credentials (`principal` and `secret`) are setup on the Mesos master via `"--credentials"` command line flag (See `./mesos-master.sh --help` for details).
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509.1</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.565.3</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -41,7 +41,6 @@
       <email>vinodkone@gmail.com</email>
     </developer>
   </developers>
-  
   <contributors>
     <contributor>
       <name>Daniel Barker</name>
@@ -74,18 +73,20 @@
       tends to lag behind a bit
     -->
     <maven-hpi-plugin.version>1.95</maven-hpi-plugin.version>
+    <mesos.version>0.21.1</mesos.version>
+    <protobuf.version>2.5.0</protobuf.version>
   </properties>
 
   <dependencies>
       <dependency>
           <groupId>org.apache.mesos</groupId>
           <artifactId>mesos</artifactId>
-          <version>0.21.0</version>
+          <version>${mesos.version}</version>
       </dependency>
       <dependency>
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
-          <version>2.5.0</version>
+          <version>${protobuf.version}</version>
       </dependency>
   </dependencies>
 


### PR DESCRIPTION
Upgraded to build with latest versions of Mesos 0.21.1 and Jenkins LTS (at least the Long Term Support release) 1.580.2.
Required some updating to Vagrantfile as well, which additionally resulted in fix for issue #76, plus now has the option to use the local plugin source instead of explicit release version if desired within the VM. This is helpful for some testing in VM, but as per previous code still defaults to released version of plugin (now latest version as well - 0.5.0)  