### PR TITLE
Make sure Jenkins is not in safe shutdown mode before provisioning

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -178,7 +178,7 @@ public class MesosCloud extends Cloud {
     final MesosSlaveInfo slaveInfo = getSlaveInfo(slaveInfos, label);
 
     try {
-      while (excessWorkload > 0) {
+      while (excessWorkload > 0 && !Jenkins.getInstance().isQuietingDown()) {
         // Start the scheduler if it's not already running.
         if (onDemandRegistration) {
           JenkinsScheduler.SUPERVISOR_LOCK.lock();


### PR DESCRIPTION
'Safe shutdown mode' in Jenkins is a state where no further builds will be performed, but Jenkins will wait for the builds are already in progress to complete before shutting down. 
There is no point in provisioning a slave if Jenkins is in safe shutdown mode since the build won't be picked up by the slave anyways. This fix addresses that.