### PR TITLE
hpi version is enough with current core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.565.3</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.565.3</version><!-- the minimum Jenkins core compatible version to run plugin on -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -68,11 +68,6 @@
   </pluginRepositories>
 
   <properties>
-    <!--
-      explicitly specifying the latest version here because one we get from the parent POM
-      tends to lag behind a bit
-    -->
-    <maven-hpi-plugin.version>1.95</maven-hpi-plugin.version>
     <mesos.version>0.21.1</mesos.version>
     <protobuf.version>2.5.0</protobuf.version>
   </properties>


### PR DESCRIPTION
1.565.3 core version has 1.106 hpi plugin version https://github.com/jenkinsci/jenkins/blob/8b3e53c7e55ab888de637586f08398524bcdcfc6/pom.xml#L493 no need to define it now
