### PR TITLE
Fix support for multiple Mesos Clouds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ work/
 .idea/
 *.iml
 *.ipr
+*.iws
 
 # Exclude Vagrant generated files
 .vagrant/

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
@@ -39,10 +39,6 @@ public class MesosComputer extends SlaveComputer {
     return (MesosSlave) super.getNode();
   }
 
-  public String getJvmArgs() {
-      return ((MesosSlave) super.getNode()).getSlaveInfo().getJvmArgs();
-  }
-
   @Override
   public HttpResponse doDoDelete() throws IOException {
     checkPermission(DELETE);

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosImpl.java
@@ -1,0 +1,53 @@
+package org.jenkinsci.plugins.mesos;
+
+import org.apache.mesos.Scheduler;
+
+public class MesosImpl extends Mesos {
+  @Override
+  public synchronized void startScheduler(String jenkinsMaster, MesosCloud mesosCloud) {
+    stopScheduler();
+    scheduler = new JenkinsScheduler(jenkinsMaster, mesosCloud);
+    scheduler.init();
+  }
+
+  @Override
+  public synchronized boolean isSchedulerRunning() {
+    return scheduler != null && scheduler.isRunning();
+  }
+
+  @Override
+  public synchronized void stopScheduler() {
+    if (scheduler != null) {
+      scheduler.stop();
+      scheduler = null;
+    }
+  }
+
+  @Override
+  public synchronized void startJenkinsSlave(SlaveRequest request, SlaveResult result) {
+    if (scheduler != null) {
+      scheduler.requestJenkinsSlave(request, result);
+    }
+  }
+
+  @Override
+  public synchronized void stopJenkinsSlave(String name) {
+    if (scheduler != null) {
+      scheduler.terminateJenkinsSlave(name);
+    }
+  }
+
+  @Override
+  public synchronized void updateScheduler(String jenkinsMaster, MesosCloud mesosCloud) {
+    scheduler.setMesosCloud(mesosCloud);
+    scheduler.setJenkinsMaster(jenkinsMaster);
+  }
+
+  private JenkinsScheduler scheduler;
+
+  @Override
+  public Scheduler getScheduler() {
+    return scheduler;
+  }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -30,10 +30,9 @@ import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
 
-import org.kohsuke.stapler.DataBoundConstructor;
-
 public class MesosSlave extends Slave {
 
+  private final MesosCloud cloud;
   private final MesosSlaveInfo slaveInfo;
   private final double cpus;
   private final int mem;
@@ -41,22 +40,26 @@ public class MesosSlave extends Slave {
   private static final Logger LOGGER = Logger.getLogger(MesosSlave.class
       .getName());
 
-  public MesosSlave(String name, int numExecutors, MesosSlaveInfo slaveInfo) throws IOException, FormException {
+  public MesosSlave(MesosCloud cloud, String name, int numExecutors, MesosSlaveInfo slaveInfo) throws IOException, FormException {
     super(name,
           slaveInfo.getLabelString(), // node description.
           StringUtils.isBlank(slaveInfo.getRemoteFSRoot()) ? "jenkins" : slaveInfo.getRemoteFSRoot().trim(),   // remoteFS.
           "" + numExecutors,
           Mode.NORMAL,
           slaveInfo.getLabelString(), // Label.
-          new MesosComputerLauncher(name),
+          new MesosComputerLauncher(cloud, name),
           new MesosRetentionStrategy(slaveInfo.getIdleTerminationMinutes()),
           Collections.<NodeProperty<?>> emptyList());
-
+    this.cloud = cloud;
     this.slaveInfo = slaveInfo;
     this.cpus = slaveInfo.getSlaveCpus() + (numExecutors * slaveInfo.getExecutorCpus());
     this.mem = slaveInfo.getSlaveMem() + (numExecutors * slaveInfo.getExecutorMem());
 
-    LOGGER.info("Constructing Mesos slave " + name);
+    LOGGER.info("Constructing Mesos slave " + name + " from cloud " + cloud.getDescription());
+  }
+
+  public MesosCloud getCloud() {
+    return this.cloud;
   }
 
   public double getCpus() {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -87,10 +87,6 @@ public class MesosSlaveInfo {
     return labelString;
   }
 
-  public void setLabelString(String labelString) {
-    this.labelString = labelString;
-  }
-
   public double getExecutorCpus() {
     return executorCpus;
   }
@@ -150,7 +146,7 @@ public class MesosSlaveInfo {
    *
    * @param jvmArgs
    *          the string of JVM arguments.
-   * @returns The cleansed JVM argument string.
+   * @return The cleansed JVM argument string.
    */
   private String cleanseJvmArgs(final String jvmArgs) {
     return jvmArgs.replaceAll(JVM_ARGS_PATTERN, "");


### PR DESCRIPTION
This is to address issue 94:
https://github.com/jenkinsci/mesos-plugin/issues/94

The Mesos object was written to be a singleton
even though Jenkins supports defining more than one.

In my case, I was trying to control 2 different clusters
(with 2 different slave tags).  Because the MesosImpl gets created by
whichever slave happens to launch first, slave tags from the other cluster
would launch in the wrong place.

While I don't LOVE this implementation, it seemed the least minimal
impact to a larger refactoring.  I basically pass a reference for the
MesosCloud to the MesosSlave.  Then I changed the Mesos.getInstance()
to take a parameter which is used as a key in a Map keyed by MesosCloud to
find the correct MesosImpl.  It was necessary to externalize the MesosImpl
inner-class to get it to compile.

I also cleaned up some unused imports, code not called, and depricated
use of Hudson for Jenkins.  You also can't override interfaces so I removed
some @Override tags