### PR TITLE
Adding WebUI field to Framework Info

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -103,12 +103,15 @@ public class JenkinsScheduler implements Scheduler {
       @Override
       public void run() {
         String targetUser = mesosCloud.getSlavesUser();
+        String webUrl = Jenkins.getInstance().getRootUrl();
+        if (webUrl == null) webUrl = System.getenv("JENKINS_URL");
         // Have Mesos fill in the current user.
         FrameworkInfo framework = FrameworkInfo.newBuilder()
           .setUser(targetUser == null ? "" : targetUser)
           .setName(mesosCloud.getFrameworkName())
           .setPrincipal(mesosCloud.getPrincipal())
           .setCheckpoint(mesosCloud.isCheckpoint())
+          .setWebuiUrl(webUrl != null ? webUrl :  "")
           .build();
 
         LOGGER.info("Initializing the Mesos driver with options"


### PR DESCRIPTION
I added a web UI field so that Mesos registers the location of the Jenkins UI. If this is not available at runtime, then the WebUI will not register.