### PR TITLE
Fix thread leak and deadlock on terminating slaves

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -211,6 +211,9 @@ public class JenkinsScheduler implements Scheduler {
            if(request.request.slave.name.equals(name)) {
              LOGGER.info("Removing enqueued mesos task " + name);
              requests.remove(request);
+             // Also signal the Thread of the MesosComputerLauncher.launch() to exit from latch.await()
+             // Otherwise the Thread will stay in WAIT forever -> Leak!
+             request.result.failed(request.request.slave);
              return;
            }
         }


### PR DESCRIPTION
Thread Leak:
When no Task was created in Mesos (due to connection error to Mesos Master or no resources available) there was no "signal" sent to the waiting MesosSlaveLauncher to finish waiting. Therefore the thread count in the Java VM increased drastically.

Deadlock:
When terminating Slaves there is a possible deadlock when the Retention check starts. We observed and experienced this two times in the last weeks. Same issue (and solution) as here (https://issues.jenkins-ci.org/browse/JENKINS-22558), but different plugin.