### PR TITLE
if we didn't have port mapping, don't try to grab them

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -322,7 +322,10 @@ public class JenkinsScheduler implements Scheduler {
             && slaveAttributesMatch(offer, slaveAttributes)) {
       return true;
     } else {
-      String requestedPorts = StringUtils.join(request.request.slaveInfo.getContainerInfo().getPortMappings().toArray(), "/");
+        String requestedPorts = "";
+        if (hasPortMappings) {
+            requestedPorts = StringUtils.join(request.request.slaveInfo.getContainerInfo().getPortMappings().toArray(), "/");
+        }
 
       LOGGER.info(
           "Offer not sufficient for slave request:\n" +


### PR DESCRIPTION
Stopping the scheduler from blowing up when we didn't supply port mappings to be part of the resource offers check.