### PR TITLE
JENKINS-28641 - Allow for configuration of a custom command shell when using docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,25 @@ At a minimum, a container path must be entered to mount the volume. A host path 
 
 Additional parameters are available for the `docker run` command, but there are too many and they change too often to list all separately. This section allows you to provide any parameter you want. Ensure that your Docker version on your Mesos slaves is compatible with the parameters you add and that the values are correctly formatted. Use the full-word parameter and not the shortcut version, as these may not work properly. Also, exclude the preceding double-dash on the parameter name. For example, enter `volumes-from` and `my_container_name` to recieve the volumes from `my_container_name`. Of course `my_container_name` must already be on the Mesos slave where the Jenkins slave will run. This shouldn't cause problems in a homogenous environment where Jenkins slaves only run on particular Mesos slaves.
 
+#### Custom shell command
+
+By default, the approach used to run a docker based jenkins slave is by passing the jenkins slave commands as arguments to 
+the standard shell e.g. ```/bin/sh -c java -jar ... ```. There may be cases (for example when wanting to run a docker-in-docker aka
+dind image) where a custom shell command is desired instead.
+
+To use a custom command shell:
+
+* Check the ```Use custom docker command shell``` box.
+* Enter an appropriate value (e.g. ```/wrapdocker```) into the ```Custom docker command shell``` text box.
+
+Under the covers, the above configuration will result in the docker container being started as follows:
+
+		docker run your-image-name /wrapdocker java -jar ....
+		
+instead of
+
+		docker run your-image-name /bin/sh -c java -jar ....
+
 Thats it!
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
   <properties>
     <mesos.version>0.21.1</mesos.version>
     <protobuf.version>2.5.0</protobuf.version>
+    <powermock.version>1.6.2</powermock.version>
   </properties>
 
   <dependencies>
@@ -96,7 +97,19 @@
       <dependency>
           <groupId>org.mockito</groupId>
           <artifactId>mockito-core</artifactId>
-          <version>1.9.5</version>
+          <version>1.10.19</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.powermock</groupId>
+          <artifactId>powermock-module-junit4</artifactId>
+          <version>${powermock.version}</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.powermock</groupId>
+          <artifactId>powermock-api-mockito</artifactId>
+          <version>${powermock.version}</version>
           <scope>test</scope>
       </dependency>
   </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -492,6 +492,8 @@ public void setJenkinsURL(String jenkinsURL) {
                   containerInfoJson.getString("type"),
                   containerInfoJson.getString("dockerImage"),
                   containerInfoJson.getBoolean("dockerPrivilegedMode"),
+                  containerInfoJson.getBoolean("useCustomDockerCommandShell"),
+                  containerInfoJson.getString ("customDockerCommandShell"),
                   volumes,
                   parameters,
                   networking,

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -183,12 +183,16 @@ public class MesosSlaveInfo {
     private final String networking;
     private static final String DEFAULT_NETWORKING = Network.BRIDGE.name();
     private final List<PortMapping> portMappings;
+    private final boolean useCustomDockerCommandShell;
+    private final String customDockerCommandShell;
     private final Boolean dockerPrivilegedMode;
 
     @DataBoundConstructor
     public ContainerInfo(String type,
                          String dockerImage,
                          Boolean dockerPrivilegedMode,
+                         boolean useCustomDockerCommandShell,
+                         String customDockerCommandShell,
                          List<Volume> volumes,
                          List<Parameter> parameters,
                          String networking,
@@ -196,6 +200,8 @@ public class MesosSlaveInfo {
       this.type = type;
       this.dockerImage = dockerImage;
       this.dockerPrivilegedMode = dockerPrivilegedMode;
+      this.useCustomDockerCommandShell = useCustomDockerCommandShell;
+      this.customDockerCommandShell = customDockerCommandShell;
       this.volumes = volumes;
       this.parameters = parameters;
 
@@ -251,6 +257,10 @@ public class MesosSlaveInfo {
     public Boolean getDockerPrivilegedMode() {
       return dockerPrivilegedMode;
     }
+
+    public boolean getUseCustomDockerCommandShell() {  return useCustomDockerCommandShell; }
+
+    public String getCustomDockerCommandShell() {  return customDockerCommandShell; }
   }
 
   public static class Parameter {

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -106,6 +106,14 @@
                                 </f:radioBlock>
                             </f:entry>
 
+                            <f:entry title="${%Use custom docker command shell}" name="useCustomDockerCommandShell" field="useCustomDockerCommandShell" >
+                              <f:checkbox default="false" checked="${slaveInfo.containerInfo.useCustomDockerCommandShell}" />
+                            </f:entry>
+
+                            <f:entry title="${%Custom docker command shell}" name="customDockerCommandShell" field="customDockerCommandShell" >
+                                <f:textbox field="customDockerCommandShell" default="" value="${slaveInfo.containerInfo.customDockerCommandShell}"/>
+                            </f:entry>
+
                             <f:entry title="${%Networking}" description="${%Specify the networking mode to use for this container}" field="networking" >
                                 <f:radioBlock id="networking.HOST" name="networking" title="${%Host}" value="HOST" inline="true" checked="${slaveInfo.containerInfo.networking == 'HOST'}" />
                                 <f:radioBlock id="networking.BRIDGE" name="networking" title="${%Bridge}" value="BRIDGE" inline="true" checked="${slaveInfo.containerInfo.networking == null || slaveInfo.containerInfo.networking == 'BRIDGE'}">

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-customDockerCommandShell.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-customDockerCommandShell.html
@@ -1,0 +1,4 @@
+<div>
+    If 'use custom docker command shell' is checked, setting this value will override the default command used to
+    launch the docker image as a jenkins slave, e.g. /wrapdocker
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-useCustomDockerCommandShell.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-useCustomDockerCommandShell.html
@@ -1,0 +1,6 @@
+<div>
+    By default, the way in which mesos runs a docker based jenkins slave image is via  /bin/sh -c 'java -DHUDSON_HOME ...'
+    Checking this option, and providing an appropriate value for the custom docker command shell parameter
+    below, will provide a way to override this custom command shell. This is often required when trying to
+    make use of a docker-in-docker (dind) image.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -1,31 +1,55 @@
 package org.jenkinsci.plugins.mesos;
 
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
 import org.apache.mesos.Protos;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest( { Jenkins.class })
 public class JenkinsSchedulerTest {
     @Mock
     private MesosCloud mesosCloud;
 
     private JenkinsScheduler jenkinsScheduler;
 
+    private static int    TEST_JENKINS_SLAVE_MEM   = 512;
+    private static String TEST_JENKINS_SLAVE_ARG   = "-Xms16m -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true";
+    private static String TEST_JENKINS_JNLP_ARG    = "";
+    private static String TEST_JENKINS_SLAVE_NAME  = "testSlave1";
+
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         when(mesosCloud.getMaster()).thenReturn("Mesos Cloud Master");
+
+        // Simulate basic Jenkins env
+        Jenkins jenkins = Mockito.mock(Jenkins.class);
+        when(jenkins.isUseSecurity()).thenReturn(false);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+
         jenkinsScheduler = new JenkinsScheduler("jenkinsMaster", mesosCloud);
+
     }
 
     @Test
@@ -118,6 +142,115 @@ public class JenkinsSchedulerTest {
         } finally {
             executorService.shutdownNow();
         }
+    }
+
+    @Test
+    public void testConstructMesosCommandInfoWithNoContainer() throws Exception {
+        JenkinsScheduler.Request request = mockMesosRequest(Boolean.FALSE, null, null);
+
+        Protos.CommandInfo.Builder commandInfoBuilder = jenkinsScheduler.getCommandInfoBuilder(request);
+        Protos.CommandInfo commandInfo = commandInfoBuilder.build();
+
+        assertTrue("Default shell config (true) should be configured when no container specified", commandInfo.getShell());
+
+        String jenkinsCommand2Run = jenkinsScheduler.generateJenkinsCommand2Run(
+                TEST_JENKINS_SLAVE_MEM,
+                TEST_JENKINS_SLAVE_ARG,
+                TEST_JENKINS_JNLP_ARG,
+                TEST_JENKINS_SLAVE_NAME);
+        assertEquals("jenkins command to run should be specified as value", jenkinsCommand2Run, commandInfo.getValue());
+        assertEquals("mesos command should have no args specified by default", 0, commandInfo.getArgumentsCount());
+    }
+
+    @Test
+    public void testConstructMesosCommandInfoWithDefaultDockerShell() throws Exception {
+        JenkinsScheduler.Request request = mockMesosRequest(Boolean.TRUE,false,null);
+
+        Protos.CommandInfo.Builder commandInfoBuilder = jenkinsScheduler.getCommandInfoBuilder(request);
+        Protos.CommandInfo commandInfo = commandInfoBuilder.build();
+
+        assertTrue("Default shell config (true) should be configured when no container specified", commandInfo.getShell());
+        String jenkinsCommand2Run = jenkinsScheduler.generateJenkinsCommand2Run(
+                TEST_JENKINS_SLAVE_MEM,
+                TEST_JENKINS_SLAVE_ARG,
+                TEST_JENKINS_JNLP_ARG,
+                TEST_JENKINS_SLAVE_NAME);
+        assertEquals("jenkins command to run should be specified as value", jenkinsCommand2Run, commandInfo.getValue());
+        assertEquals("mesos command should have no args specified by default", 0, commandInfo.getArgumentsCount());
+    }
+
+    @Test
+    public void testConstructMesosCommandInfoWithCustomDockerShell() throws Exception {
+        JenkinsScheduler.Request request = mockMesosRequest(Boolean.TRUE, true, "/bin/wrapdocker");
+
+        Protos.CommandInfo.Builder commandInfoBuilder = jenkinsScheduler.getCommandInfoBuilder(request);
+        Protos.CommandInfo commandInfo = commandInfoBuilder.build();
+
+        assertFalse("shell should be configured as false when using a custom shell", commandInfo.getShell());
+        assertEquals("Custom shell should be specified as value", "/bin/wrapdocker", commandInfo.getValue());
+        String jenkinsCommand2Run = jenkinsScheduler.generateJenkinsCommand2Run(
+                TEST_JENKINS_SLAVE_MEM,
+                TEST_JENKINS_SLAVE_ARG,
+                TEST_JENKINS_JNLP_ARG,
+                TEST_JENKINS_SLAVE_NAME);
+
+        assertEquals("args should now consist of the single original command ", 1, commandInfo.getArgumentsCount());
+        assertEquals("args should now consist of the original command ", jenkinsCommand2Run, commandInfo.getArguments(0));
+    }
+
+    @Test(expected = java.lang.IllegalArgumentException.class)
+    public void testConstructMesosCommandInfoWithBlankCustomDockerShell() throws Exception {
+        JenkinsScheduler.Request request = mockMesosRequest(Boolean.TRUE, true, " ");
+
+        jenkinsScheduler.getCommandInfoBuilder(request);
+    }
+
+    @Test(expected = java.lang.IllegalArgumentException.class)
+    public void testConstructMesosCommandInfoWithNullCustomDockerShell() throws Exception {
+        JenkinsScheduler.Request request = mockMesosRequest(Boolean.TRUE, true, null);
+
+        jenkinsScheduler.getCommandInfoBuilder(request);
+    }
+
+    private JenkinsScheduler.Request mockMesosRequest(
+            Boolean useDocker,
+            Boolean useCustomDockerCommandShell,
+            String customDockerCommandShell) throws Descriptor.FormException {
+
+        MesosSlaveInfo.ContainerInfo containerInfo = null;
+        if (useDocker) {
+            containerInfo = new MesosSlaveInfo.ContainerInfo(
+                    "docker",
+                    "test-docker-in-docker-image",
+                    Boolean.TRUE,
+                    useCustomDockerCommandShell,
+                    customDockerCommandShell,
+                    Collections.<MesosSlaveInfo.Volume>emptyList(),
+                    Collections.<MesosSlaveInfo.Parameter>emptyList(),
+                    Protos.ContainerInfo.DockerInfo.Network.HOST.name(),
+                    Collections.<MesosSlaveInfo.PortMapping>emptyList());
+        }
+
+        MesosSlaveInfo mesosSlaveInfo = new MesosSlaveInfo(
+                "testLabelString",  // labelString,
+                "0.2",              // slaveCpus,
+                "512",              //slaveMem,
+                "2",                // maxExecutors,
+                "0.2",              // executorCpus,
+                "512",              // executorMem,
+                "remoteFSRoot",     // remoteFSRoot,
+                "2",                // idleTerminationMinutes,
+                null,               // slaveAttributes,
+                null,               // jvmArgs,
+                null,               //jnlpArgs,
+                null,               // externalContainerInfo,
+                containerInfo,      // containerInfo,
+                null);              //additionalURIs
+        Mesos.SlaveRequest slaveReq = new Mesos.SlaveRequest(new Mesos.JenkinsSlave(TEST_JENKINS_SLAVE_NAME),0.2d,TEST_JENKINS_SLAVE_MEM,mesosSlaveInfo);
+        Mesos.SlaveResult slaveResult = Mockito.mock(Mesos.SlaveResult.class);
+
+        return jenkinsScheduler.new Request(slaveReq,slaveResult);
+
     }
 
     private Protos.Offer createOfferWithVariableRanges(long rangeBegin, long rangeEnd) {


### PR DESCRIPTION
This PR addresses https://issues.jenkins-ci.org/browse/JENKINS-28641 which makes it possible to configure the use of a custom command shell when executing a docker based slave, which is helpful when trying to run a docker-in-docker / dind image.

This issue was also raised in the google group here:
https://groups.google.com/forum/#!topic/jenkins-mesos/JgFCmqOO7Fg 