### PR TITLE
reduce logging level for some status things

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -249,7 +249,7 @@ public class JenkinsScheduler implements Scheduler {
       for (Request request : requests) {
         if (matches(offer, request)) {
           matched = true;
-          LOGGER.info("Offer matched! Creating mesos task");
+          LOGGER.fine("Offer matched! Creating mesos task");
           createMesosTask(offer, request);
           requests.remove(request);
           break;
@@ -300,7 +300,7 @@ public class JenkinsScheduler implements Scheduler {
     if (requestedCpus <= cpus && requestedMem <= mem && slaveAttributesMatch(offer, slaveAttributes)) {
       return true;
     } else {
-      LOGGER.info(
+      LOGGER.fine(
           "Offer not sufficient for slave request:\n" +
           offer.getResourcesList().toString() +
           "\n" + offer.getAttributesList().toString() +
@@ -465,13 +465,13 @@ public class JenkinsScheduler implements Scheduler {
   @Override
   public void statusUpdate(SchedulerDriver driver, TaskStatus status) {
     TaskID taskId = status.getTaskId();
-    LOGGER.info("Status update: task " + taskId + " is in state " + status.getState() +
+    LOGGER.fine("Status update: task " + taskId + " is in state " + status.getState() +
                 (status.hasMessage() ? " with message '" + status.getMessage() + "'" : ""));
 
     if (!results.containsKey(taskId)) {
       // The task might not be present in the 'results' map if this is a duplicate terminal
       // update.
-      LOGGER.info("Ignoring status update " + status.getState() + " for unknown task " + taskId);
+      LOGGER.fine("Ignoring status update " + status.getState() + " for unknown task " + taskId);
       return;
     }
 


### PR DESCRIPTION
Lowering the logging level from INFO to FINE for a few items.
The noisiest one is the 'not matching slave' message in mesos environments
where only a few of the slaves are jenkins candidates.  The non-matching ones
dump many large json objects into the logs which really falls more into
the debugging camp hence the lower level