### PR TITLE
reduce logging level for some status things

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -251,7 +251,7 @@ public class JenkinsScheduler implements Scheduler {
       for (Request request : requests) {
         if (matches(offer, request)) {
           matched = true;
-          LOGGER.info("Offer matched! Creating mesos task");
+          LOGGER.fine("Offer matched! Creating mesos task");
 
           try {
               createMesosTask(offer, request);
@@ -324,7 +324,7 @@ public class JenkinsScheduler implements Scheduler {
     } else {
       String requestedPorts = StringUtils.join(request.request.slaveInfo.getContainerInfo().getPortMappings().toArray(), "/");
 
-      LOGGER.info(
+      LOGGER.fine(
           "Offer not sufficient for slave request:\n" +
           offer.getResourcesList().toString() +
           "\n" + offer.getAttributesList().toString() +
@@ -566,13 +566,13 @@ public class JenkinsScheduler implements Scheduler {
   @Override
   public void statusUpdate(SchedulerDriver driver, TaskStatus status) {
     TaskID taskId = status.getTaskId();
-    LOGGER.info("Status update: task " + taskId + " is in state " + status.getState() +
+    LOGGER.fine("Status update: task " + taskId + " is in state " + status.getState() +
                 (status.hasMessage() ? " with message '" + status.getMessage() + "'" : ""));
 
     if (!results.containsKey(taskId)) {
       // The task might not be present in the 'results' map if this is a duplicate terminal
       // update.
-      LOGGER.info("Ignoring status update " + status.getState() + " for unknown task " + taskId);
+      LOGGER.fine("Ignoring status update " + status.getState() + " for unknown task " + taskId);
       return;
     }
 


### PR DESCRIPTION
Lowering the logging level from INFO to FINE for a few items.
The noisiest one is the 'not matching slave' message in mesos environments
where only a few of the slaves are jenkins candidates.  The non-matching ones
dump many large json objects into the logs which really falls more into
the debugging camp hence the lower level