### PR TITLE
fix NPE in 0.7.0 with old serialized data

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -181,6 +181,7 @@ public class MesosSlaveInfo {
     private final List<Volume> volumes;
     private final List<Parameter> parameters;
     private final String networking;
+    private static final String DEFAULT_NETWORKING = Network.BRIDGE.name();
     private final List<PortMapping> portMappings;
 
     @DataBoundConstructor
@@ -192,7 +193,7 @@ public class MesosSlaveInfo {
       this.parameters = parameters;
 
       if (networking == null) {
-          this.networking = Network.BRIDGE.toString();
+          this.networking = DEFAULT_NETWORKING;
       } else {
           this.networking = networking;
       }
@@ -221,11 +222,19 @@ public class MesosSlaveInfo {
     }
 
     public String getNetworking() {
-      return networking;
+      if (networking != null) {
+        return networking;
+      } else {
+        return DEFAULT_NETWORKING;
+      }
     }
 
     public List<PortMapping> getPortMappings() {
-      return portMappings;
+      if (portMappings != null) {
+        return portMappings;
+      } else {
+        return Collections.emptyList();
+      }
     }
 
     public boolean hasPortMappings() {


### PR DESCRIPTION
The stored protobufs pre-0.7.0 basically deserialed the new fields
as nulls.  By adding some guards on the getters we avoid 2 NPEs.
when getting the port mappings (want empty collection) and
also when getting networking definition (use default bridge value).

Fixes https://github.com/jenkinsci/mesos-plugin/issues/113 and https://github.com/jenkinsci/mesos-plugin/issues/111

Please cut 0.7.1 ASAP.

Thanks!