### PR TITLE
fix hashcode lookup resetting framework on save

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -146,6 +146,26 @@ public class MesosCloud extends Cloud {
     }
   }
 
+  // Since MesosCloud is used as a key to a Hashmap, we need to set equals/hashcode
+  // or lookups won't work if any fields are changed.  Use master string as the key since
+  // the rest of this code assumes it is unique among the Cloud objects.
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    MesosCloud that = (MesosCloud) o;
+
+    if (master != null ? !master.equals(that.master) : that.master != null) return false;
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return master != null ? master.hashCode() : 0;
+  }
+
   public void restartMesos() {
 
     if(!nativeLibraryLoaded) {


### PR DESCRIPTION
With the fix to support multiple MesosClouds (https://github.com/jenkinsci/mesos-plugin/pull/96) with a HashMap lookup keyed on MesosCloud objects, I neglected to add equals/hashcode.  This means that if you hit 'save', but actually not change anything we go down the path of resetting the framework (which actually registers a second framework and leaves the first one in-tact) rather than calling the ``updateScheduler`` method.  Without hashcode being properly implemented, the Mesos.getInstance() lookup will always fail.  Since this code only seems to care about the master string (or master zk string), that is what I based the hashcode/equals code on.

    // Restart the scheduler if the master has changed or a scheduler is not up.
    if (!master.equals(staticMaster) || !Mesos.getInstance(this).isSchedulerRunning()) {
      if (!master.equals(staticMaster)) {
        LOGGER.info("Mesos master changed, restarting the scheduler");
        staticMaster = master;
      } else {
        LOGGER.info("Scheduler was down, restarting the scheduler");
      }

      Mesos.getInstance(this).stopScheduler();
      Mesos.getInstance(this).startScheduler(jenkinsRootURL, this);
    } else {
      Mesos.getInstance(this).updateScheduler(jenkinsRootURL, this);
      LOGGER.info("Mesos master has not changed, leaving the scheduler running");
    }


Now I'm no longer seeing the ``Scheduler was down, restarting the scheduler`` message.  Instead I see the expected log message:

    Jun 08, 2015 3:37:02 AM INFO org.jenkinsci.plugins.mesos.MesosCloud restartMesos
    Mesos master has not changed, leaving the scheduler running
