### PR TITLE
Support one off slaves on the job level for mesos slaves.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.2</powermock.version>
     <assertj.version>2.1.0</assertj.version>
+    <guava.version>18.0</guava.version>
   </properties>
 
   <dependencies>
@@ -124,6 +125,11 @@
           <artifactId>assertj-core</artifactId>
           <version>${assertj.version}</version>
           <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>${guava.version}</version>
       </dependency>
   </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCleanupThread.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCleanupThread.java
@@ -1,0 +1,115 @@
+package org.jenkinsci.plugins.mesos;
+
+import java.io.IOException;
+import java.util.logging.Level;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import hudson.Extension;
+import hudson.model.AsyncPeriodicWork;
+import hudson.model.Computer;
+import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
+
+/**
+ This file is part of the JCloud Jenkins Plugin. (https://github.com/jenkinsci/jclouds-plugin)
+ commit id 20c6ca884abb172b27d0af82545c8915ce08f618.
+
+ This file was modified to work with the Mesos Jenkins plugin and based off the JClouds Jenkins Plugin.
+
+ According to the Jenkins Plugin guide (https://wiki.jenkins-ci.org/display/JENKINS/Before+starting+a+new+plugin),
+ If no license is defined in the form of a header, LICENSE file, or in the license section, the code is assumed to be
+ under The MIT License.
+
+ The MIT License (MIT)
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+@Extension
+public class MesosCleanupThread extends AsyncPeriodicWork {
+
+    public MesosCleanupThread() {
+        super("Mesos pending deletion slave cleanup");
+    }
+
+    @Override
+    public long getRecurrencePeriod() {
+        return MIN * 1;
+    }
+
+    public static void invoke() {
+        getInstance().run();
+    }
+
+    private static MesosCleanupThread getInstance() {
+        return Jenkins.getInstance().getExtensionList(AsyncPeriodicWork.class).get(MesosCleanupThread.class);
+    }
+
+    @Override
+    protected void execute(TaskListener listener) {
+        final ImmutableList.Builder<ListenableFuture<?>> deletedNodesBuilder = ImmutableList.<ListenableFuture<?>>builder();
+        ListeningExecutorService executor = MoreExecutors.listeningDecorator(Computer.threadPoolForRemoting);
+        final ImmutableList.Builder<MesosComputer> computersToDeleteBuilder = ImmutableList.<MesosComputer>builder();
+
+        for (final Computer c : Jenkins.getInstance().getComputers()) {
+            if (MesosComputer.class.isInstance(c)) {
+                MesosSlave mesosSlave = (MesosSlave) c.getNode();
+
+                if (mesosSlave != null && mesosSlave.isPendingDelete()) {
+                    final MesosComputer comp = (MesosComputer) c;
+                    computersToDeleteBuilder.add(comp);
+                    logger.log(Level.INFO, "Marked " + comp.getName() + " for deletion");
+                    ListenableFuture<?> f = executor.submit(new Runnable() {
+                        public void run() {
+                            logger.log(Level.INFO, "Deleting pending node " + comp.getName());
+                            try {
+                                comp.getNode().terminate();
+                            } catch (RuntimeException e) {
+                                logger.log(Level.WARNING, "Failed to disconnect and delete " + comp.getName() + ": " + e.getMessage());
+                                throw e;
+                            }
+                        }
+                    });
+                    deletedNodesBuilder.add(f);
+                } else {
+                    logger.log(Level.FINE, c.getName() + " with slave " + mesosSlave +
+                            " is not pending deletion or the slave is null");
+                }
+            } else {
+                logger.log(Level.FINER, c.getName() + " is not a mesos computer, it is a " + c.getClass().getName());
+            }
+        }
+
+        Futures.getUnchecked(Futures.successfulAsList(deletedNodesBuilder.build()));
+
+        for (MesosComputer c : computersToDeleteBuilder.build()) {
+            try {
+                c.deleteSlave();
+            } catch (IOException e) {
+                logger.log(Level.WARNING, "Failed to disconnect and delete " + c.getName() + ": " + e.getMessage());
+            } catch (InterruptedException e) {
+                logger.log(Level.WARNING, "Failed to disconnect and delete " + c.getName() + ": " + e.getMessage());
+            }
+
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputer.java
@@ -14,10 +14,12 @@
  */
 package org.jenkinsci.plugins.mesos;
 
+import hudson.model.Hudson;
 import hudson.model.Slave;
 import hudson.slaves.SlaveComputer;
 
 import java.io.IOException;
+import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 
@@ -30,6 +32,8 @@ import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.WebMethod;
 
 public class MesosComputer extends SlaveComputer {
+  private static final Logger LOGGER = Logger.getLogger(MesosComputer.class.getName());
+
   public MesosComputer(Slave slave) {
     super(slave);
   }
@@ -51,5 +55,24 @@ public class MesosComputer extends SlaveComputer {
   @WebMethod(name="slave-agent.jnlp")
   public HttpResponse doSlaveAgentJnlp(StaplerRequest req, StaplerResponse res) throws IOException, ServletException {
 	  return new EncryptedSlaveAgentJnlpFile(this, "mesos-slave-agent.jnlp.jelly", getName(), CONNECT);
+  }
+
+  /**
+   * Delete the slave, terminate the instance. Can be called either by doDoDelete() or from MesosRetentionStrategy.
+   *
+   * @throws InterruptedException
+   */
+  public void deleteSlave() throws IOException, InterruptedException {
+      LOGGER.info("Terminating " + getName() + " slave");
+      MesosSlave slave = getNode();
+
+      // Slave already deleted
+      if (slave == null) return;
+
+      if (slave.getChannel() != null) {
+          slave.getChannel().close();
+      }
+      slave.terminate();
+      Hudson.getInstance().removeNode(slave);
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
@@ -103,6 +103,9 @@ public class MesosComputerLauncher extends ComputerLauncher {
     latch.await();
 
     if (state == State.RUNNING) {
+      // Since we just launched a slave, remove it from pending deletion in case it was marked previously while
+      // we were waiting for resources to be available
+      computer.getNode().setPendingDelete(false);
       logger.println("Successfully launched slave" + name);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSingleUseSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSingleUseSlave.java
@@ -1,0 +1,95 @@
+package org.jenkinsci.plugins.mesos;
+
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.BuildListener;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.slaves.OfflineCause;
+import hudson.tasks.BuildWrapper;
+import hudson.tasks.BuildWrapperDescriptor;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ This file is part of the JCloud Jenkins Plugin. (https://github.com/jenkinsci/jclouds-plugin)
+ commit id 20c6ca884abb172b27d0af82545c8915ce08f618.
+
+ This file was modified to work with the Mesos Jenkins plugin and based off the JClouds Jenkins Plugin.
+
+ According to the Jenkins Plugin guide (https://wiki.jenkins-ci.org/display/JENKINS/Before+starting+a+new+plugin),
+ If no license is defined in the form of a header, LICENSE file, or in the license section, the code is assumed to be
+ under The MIT License.
+
+ The MIT License (MIT)
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+public class MesosSingleUseSlave extends BuildWrapper {
+    private static final Logger LOGGER = Logger.getLogger(MesosSingleUseSlave.class.getName());
+
+    @DataBoundConstructor
+    public MesosSingleUseSlave() {
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Environment setUp(AbstractBuild build, Launcher launcher, final BuildListener listener) {
+        if (MesosComputer.class.isInstance(build.getExecutor().getOwner())) {
+            final MesosComputer c = (MesosComputer) build.getExecutor().getOwner();
+            return new Environment() {
+                @Override
+                public boolean tearDown(AbstractBuild build, final BuildListener listener) throws IOException, InterruptedException {
+                    LOGGER.warning("Single-use slave " + c.getName() + " getting torn down.");
+                    c.setTemporarilyOffline(true, OfflineCause.create(Messages._SingleUseCause()));
+                    return true;
+                }
+            };
+        } else {
+            return new Environment() {
+                @Override
+                public boolean tearDown(AbstractBuild build, final BuildListener listener) throws IOException, InterruptedException {
+                    LOGGER.fine("Not a single use slave, this is a " + build.getExecutor().getOwner().getClass());
+                    return true;
+                }
+            };
+        }
+
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends BuildWrapperDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Mesos Single-Use Slave";
+        }
+
+        @Override
+        @SuppressWarnings("rawtypes")
+        public boolean isApplicable(AbstractProject item) {
+            return true;
+        }
+
+    }
+}
+

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -36,6 +36,7 @@ public class MesosSlave extends Slave {
   private final MesosSlaveInfo slaveInfo;
   private final double cpus;
   private final int mem;
+  private boolean pendingDelete;
 
   private static final Logger LOGGER = Logger.getLogger(MesosSlave.class
       .getName());
@@ -111,6 +112,14 @@ public class MesosSlave extends Slave {
 
   private String getInstanceId() {
     return getNodeName();
+  }
+
+  public boolean isPendingDelete() {
+      return pendingDelete;
+  }
+
+  public void setPendingDelete(boolean pendingDelete) {
+      this.pendingDelete = pendingDelete;
   }
 
   public void idleTimeout() {

--- a/src/main/resources/org/jenkinsci/plugins/mesos/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/Messages.properties
@@ -1,0 +1,2 @@
+SingleUseCause=Single-use slave has already been used and is pending removal.
+DeletedCause=The slave is offline and is pending removal.

--- a/src/test/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategyTest.java
@@ -72,7 +72,6 @@ public class MesosRetentionStrategyTest {
     mesosRetentionStrategy.check(mesosComputer);
 
     // Then
-    verify(mesosComputer).isOffline();
     verify(mesosSlave, never()).terminate();
   }
 


### PR DESCRIPTION
Fixes #48

Based off the JClouds Jenkins plugin's implementation. The slave, on teardown, will mark temporarily offline, and thus no longer take any jobs. The Mesos retention strategy will then set it as pending deletion after the idle period to protect against post-build actions from terminating the slave too soon. The final step is the asynchronous period work in MesosCleanupTask which will terminate the pending deletion slave.