### PR TITLE
Take into account new mesos status TASK_ERROR

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -657,6 +657,7 @@ public class JenkinsScheduler implements Scheduler {
       result.result.finished(result.slave);
       terminalState = true;
       break;
+    case TASK_ERROR:
     case TASK_FAILED:
     case TASK_KILLED:
     case TASK_LOST:


### PR DESCRIPTION
This status TASK_ERROR has been introduced in mesos 0.21, but is only sent starting from 0.22.

The PR only add the new status to the JenkinsScheduler.java in the case block of the statusUpdate() function. This avoids a Java exception crashing the scheduler.

It may need future "functional" adaptations regarding why such a status is sent by mesos.

https://github.com/jenkinsci/mesos-plugin/issues/125