### PR TITLE
JENKINS-28641 - Allow for configuration of a custom command shell when using docker

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -493,6 +493,8 @@ public void setJenkinsURL(String jenkinsURL) {
                   containerInfoJson.getString("type"),
                   containerInfoJson.getString("dockerImage"),
                   containerInfoJson.getBoolean("dockerPrivilegedMode"),
+                  containerInfoJson.getBoolean("useCustomDockerCommandShell"),
+                  containerInfoJson.getString ("customDockerCommandShell"),
                   volumes,
                   parameters,
                   networking,

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -193,12 +193,16 @@ public class MesosSlaveInfo {
     private final String networking;
     private static final String DEFAULT_NETWORKING = Network.BRIDGE.name();
     private final List<PortMapping> portMappings;
+    private final boolean useCustomDockerCommandShell;
+    private final String customDockerCommandShell;
     private final Boolean dockerPrivilegedMode;
 
     @DataBoundConstructor
     public ContainerInfo(String type,
                          String dockerImage,
                          Boolean dockerPrivilegedMode,
+                         boolean useCustomDockerCommandShell,
+                         String customDockerCommandShell,
                          List<Volume> volumes,
                          List<Parameter> parameters,
                          String networking,
@@ -206,6 +210,8 @@ public class MesosSlaveInfo {
       this.type = type;
       this.dockerImage = dockerImage;
       this.dockerPrivilegedMode = dockerPrivilegedMode;
+      this.useCustomDockerCommandShell = useCustomDockerCommandShell;
+      this.customDockerCommandShell = customDockerCommandShell;
       this.volumes = volumes;
       this.parameters = parameters;
 
@@ -261,6 +267,10 @@ public class MesosSlaveInfo {
     public Boolean getDockerPrivilegedMode() {
       return dockerPrivilegedMode;
     }
+
+    public boolean getUseCustomDockerCommandShell() {  return useCustomDockerCommandShell; }
+
+    public String getCustomDockerCommandShell() {  return customDockerCommandShell; }
   }
 
   public static class Parameter {

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -109,6 +109,14 @@
                                 </f:radioBlock>
                             </f:entry>
 
+                            <f:entry title="${%Use custom docker command shell}" name="useCustomDockerCommandShell" field="useCustomDockerCommandShell" >
+                              <f:checkbox default="false" checked="${slaveInfo.containerInfo.useCustomDockerCommandShell}" />
+                            </f:entry>
+
+                            <f:entry title="${%Custom docker command shell}" name="customDockerCommandShell" field="customDockerCommandShell" >
+                                <f:textbox field="customDockerCommandShell" default="" value="${slaveInfo.containerInfo.customDockerCommandShell}"/>
+                            </f:entry>
+
                             <f:entry title="${%Networking}" description="${%Specify the networking mode to use for this container}" field="networking" >
                                 <f:radioBlock id="networking.HOST" name="networking" title="${%Host}" value="HOST" inline="true" checked="${slaveInfo.containerInfo.networking == 'HOST'}" />
                                 <f:radioBlock id="networking.BRIDGE" name="networking" title="${%Bridge}" value="BRIDGE" inline="true" checked="${slaveInfo.containerInfo.networking == null || slaveInfo.containerInfo.networking == 'BRIDGE'}">

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-customDockerCommandShell.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-customDockerCommandShell.html
@@ -1,0 +1,4 @@
+<div>
+    If 'use custom docker command shell' is checked, setting this value will override the default command used to
+    launch the docker image as a jenkins slave, e.g. /wrapdocker
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-useCustomDockerCommandShell.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-useCustomDockerCommandShell.html
@@ -1,0 +1,6 @@
+<div>
+    By default, the way in which mesos runs a docker based jenkins slave image is via  /bin/sh -c 'java -DHUDSON_HOME ...'
+    Checking this option, and providing an appropriate value for the custom docker command shell parameter
+    below, will provide a way to override this custom command shell. This is often required when trying to
+    make use of a docker-in-docker (dind) image.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -1,31 +1,56 @@
 package org.jenkinsci.plugins.mesos;
 
+import hudson.model.Descriptor;
+import hudson.model.Node;
+import jenkins.model.Jenkins;
 import org.apache.mesos.Protos;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest( { Jenkins.class })
 public class JenkinsSchedulerTest {
     @Mock
     private MesosCloud mesosCloud;
 
     private JenkinsScheduler jenkinsScheduler;
 
+    private static int    TEST_JENKINS_SLAVE_MEM   = 512;
+    private static String TEST_JENKINS_SLAVE_ARG   = "-Xms16m -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true";
+    private static String TEST_JENKINS_JNLP_ARG    = "";
+    private static String TEST_JENKINS_SLAVE_NAME  = "testSlave1";
+
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         when(mesosCloud.getMaster()).thenReturn("Mesos Cloud Master");
+
+        // Simulate basic Jenkins env
+        Jenkins jenkins = Mockito.mock(Jenkins.class);
+        when(jenkins.isUseSecurity()).thenReturn(false);
+        PowerMockito.mockStatic(Jenkins.class);
+        Mockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+
         jenkinsScheduler = new JenkinsScheduler("jenkinsMaster", mesosCloud);
+
     }
 
     @Test
@@ -118,6 +143,116 @@ public class JenkinsSchedulerTest {
         } finally {
             executorService.shutdownNow();
         }
+    }
+
+    @Test
+    public void testConstructMesosCommandInfoWithNoContainer() throws Exception {
+        JenkinsScheduler.Request request = mockMesosRequest(Boolean.FALSE, null, null);
+
+        Protos.CommandInfo.Builder commandInfoBuilder = jenkinsScheduler.getCommandInfoBuilder(request);
+        Protos.CommandInfo commandInfo = commandInfoBuilder.build();
+
+        assertTrue("Default shell config (true) should be configured when no container specified", commandInfo.getShell());
+
+        String jenkinsCommand2Run = jenkinsScheduler.generateJenkinsCommand2Run(
+                TEST_JENKINS_SLAVE_MEM,
+                TEST_JENKINS_SLAVE_ARG,
+                TEST_JENKINS_JNLP_ARG,
+                TEST_JENKINS_SLAVE_NAME);
+        assertEquals("jenkins command to run should be specified as value", jenkinsCommand2Run, commandInfo.getValue());
+        assertEquals("mesos command should have no args specified by default", 0, commandInfo.getArgumentsCount());
+    }
+
+    @Test
+    public void testConstructMesosCommandInfoWithDefaultDockerShell() throws Exception {
+        JenkinsScheduler.Request request = mockMesosRequest(Boolean.TRUE,false,null);
+
+        Protos.CommandInfo.Builder commandInfoBuilder = jenkinsScheduler.getCommandInfoBuilder(request);
+        Protos.CommandInfo commandInfo = commandInfoBuilder.build();
+
+        assertTrue("Default shell config (true) should be configured when no container specified", commandInfo.getShell());
+        String jenkinsCommand2Run = jenkinsScheduler.generateJenkinsCommand2Run(
+                TEST_JENKINS_SLAVE_MEM,
+                TEST_JENKINS_SLAVE_ARG,
+                TEST_JENKINS_JNLP_ARG,
+                TEST_JENKINS_SLAVE_NAME);
+        assertEquals("jenkins command to run should be specified as value", jenkinsCommand2Run, commandInfo.getValue());
+        assertEquals("mesos command should have no args specified by default", 0, commandInfo.getArgumentsCount());
+    }
+
+    @Test
+    public void testConstructMesosCommandInfoWithCustomDockerShell() throws Exception {
+        JenkinsScheduler.Request request = mockMesosRequest(Boolean.TRUE, true, "/bin/wrapdocker");
+
+        Protos.CommandInfo.Builder commandInfoBuilder = jenkinsScheduler.getCommandInfoBuilder(request);
+        Protos.CommandInfo commandInfo = commandInfoBuilder.build();
+
+        assertFalse("shell should be configured as false when using a custom shell", commandInfo.getShell());
+        assertEquals("Custom shell should be specified as value", "/bin/wrapdocker", commandInfo.getValue());
+        String jenkinsCommand2Run = jenkinsScheduler.generateJenkinsCommand2Run(
+                TEST_JENKINS_SLAVE_MEM,
+                TEST_JENKINS_SLAVE_ARG,
+                TEST_JENKINS_JNLP_ARG,
+                TEST_JENKINS_SLAVE_NAME);
+
+        assertEquals("args should now consist of the single original command ", 1, commandInfo.getArgumentsCount());
+        assertEquals("args should now consist of the original command ", jenkinsCommand2Run, commandInfo.getArguments(0));
+    }
+
+    @Test(expected = java.lang.IllegalArgumentException.class)
+    public void testConstructMesosCommandInfoWithBlankCustomDockerShell() throws Exception {
+        JenkinsScheduler.Request request = mockMesosRequest(Boolean.TRUE, true, " ");
+
+        jenkinsScheduler.getCommandInfoBuilder(request);
+    }
+
+    @Test(expected = java.lang.IllegalArgumentException.class)
+    public void testConstructMesosCommandInfoWithNullCustomDockerShell() throws Exception {
+        JenkinsScheduler.Request request = mockMesosRequest(Boolean.TRUE, true, null);
+
+        jenkinsScheduler.getCommandInfoBuilder(request);
+    }
+
+    private JenkinsScheduler.Request mockMesosRequest(
+            Boolean useDocker,
+            Boolean useCustomDockerCommandShell,
+            String customDockerCommandShell) throws Descriptor.FormException {
+
+        MesosSlaveInfo.ContainerInfo containerInfo = null;
+        if (useDocker) {
+            containerInfo = new MesosSlaveInfo.ContainerInfo(
+                    "docker",
+                    "test-docker-in-docker-image",
+                    Boolean.TRUE,
+                    useCustomDockerCommandShell,
+                    customDockerCommandShell,
+                    Collections.<MesosSlaveInfo.Volume>emptyList(),
+                    Collections.<MesosSlaveInfo.Parameter>emptyList(),
+                    Protos.ContainerInfo.DockerInfo.Network.HOST.name(),
+                    Collections.<MesosSlaveInfo.PortMapping>emptyList());
+        }
+
+        MesosSlaveInfo mesosSlaveInfo = new MesosSlaveInfo(
+                "testLabelString",  // labelString,
+                Node.Mode.NORMAL,
+                "0.2",              // slaveCpus,
+                "512",              //slaveMem,
+                "2",                // maxExecutors,
+                "0.2",              // executorCpus,
+                "512",              // executorMem,
+                "remoteFSRoot",     // remoteFSRoot,
+                "2",                // idleTerminationMinutes,
+                null,               // slaveAttributes,
+                null,               // jvmArgs,
+                null,               //jnlpArgs,
+                null,               // externalContainerInfo,
+                containerInfo,      // containerInfo,
+                null);              //additionalURIs
+        Mesos.SlaveRequest slaveReq = new Mesos.SlaveRequest(new Mesos.JenkinsSlave(TEST_JENKINS_SLAVE_NAME),0.2d,TEST_JENKINS_SLAVE_MEM,mesosSlaveInfo);
+        Mesos.SlaveResult slaveResult = Mockito.mock(Mesos.SlaveResult.class);
+
+        return jenkinsScheduler.new Request(slaveReq,slaveResult);
+
     }
 
     private Protos.Offer createOfferWithVariableRanges(long rangeBegin, long rangeEnd) {


### PR DESCRIPTION
This PR addresses https://issues.jenkins-ci.org/browse/JENKINS-28641 which makes it possible to configure the use of a custom command shell when executing a docker based slave, which is helpful when trying to run a docker-in-docker / dind image.

This issue was also raised in the google group here:
https://groups.google.com/forum/#!topic/jenkins-mesos/JgFCmqOO7Fg

It is a rebased, squashed and merged version of https://github.com/jenkinsci/mesos-plugin/pull/112 which was closed in error
Ping @nikore @maselvaraj @bacoboy 