### PR TITLE
implemented mesos force_pull_image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
   </pluginRepositories>
 
   <properties>
-    <mesos.version>0.21.1</mesos.version>
+    <mesos.version>0.22.1</mesos.version>
     <protobuf.version>2.5.0</protobuf.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.2</powermock.version>

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -546,7 +546,8 @@ public class JenkinsScheduler implements Scheduler {
           LOGGER.info("Launching in Docker Mode:" + containerInfo.getDockerImage());
           DockerInfo.Builder dockerInfoBuilder = DockerInfo.newBuilder() //
               .setImage(containerInfo.getDockerImage())
-              .setPrivileged(containerInfo.getDockerPrivilegedMode() != null ? containerInfo.getDockerPrivilegedMode() : false);
+              .setPrivileged(containerInfo.getDockerPrivilegedMode() != null ? containerInfo.getDockerPrivilegedMode() : false)
+              .setForcePullImage(containerInfo.getDockerForcePullImage() != null ? containerInfo.getDockerForcePullImage() : false);
 
           if (containerInfo.getParameters() != null) {
             for (MesosSlaveInfo.Parameter parameter : containerInfo.getParameters()) {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -493,6 +493,7 @@ public void setJenkinsURL(String jenkinsURL) {
                   containerInfoJson.getString("type"),
                   containerInfoJson.getString("dockerImage"),
                   containerInfoJson.getBoolean("dockerPrivilegedMode"),
+                  containerInfoJson.getBoolean("dockerForcePullImage"),
                   containerInfoJson.getBoolean("useCustomDockerCommandShell"),
                   containerInfoJson.getString ("customDockerCommandShell"),
                   volumes,

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -196,11 +196,13 @@ public class MesosSlaveInfo {
     private final boolean useCustomDockerCommandShell;
     private final String customDockerCommandShell;
     private final Boolean dockerPrivilegedMode;
+    private final Boolean dockerForcePullImage;
 
     @DataBoundConstructor
     public ContainerInfo(String type,
                          String dockerImage,
                          Boolean dockerPrivilegedMode,
+                         Boolean dockerForcePullImage,
                          boolean useCustomDockerCommandShell,
                          String customDockerCommandShell,
                          List<Volume> volumes,
@@ -210,6 +212,7 @@ public class MesosSlaveInfo {
       this.type = type;
       this.dockerImage = dockerImage;
       this.dockerPrivilegedMode = dockerPrivilegedMode;
+      this.dockerForcePullImage = dockerForcePullImage;
       this.useCustomDockerCommandShell = useCustomDockerCommandShell;
       this.customDockerCommandShell = customDockerCommandShell;
       this.volumes = volumes;
@@ -266,6 +269,10 @@ public class MesosSlaveInfo {
 
     public Boolean getDockerPrivilegedMode() {
       return dockerPrivilegedMode;
+    }
+
+    public Boolean getDockerForcePullImage() {
+      return dockerForcePullImage;
     }
 
     public boolean getUseCustomDockerCommandShell() {  return useCustomDockerCommandShell; }

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -106,6 +106,9 @@
                                     <f:entry title="${%Docker Privileged Mode}" description="This will start the image using Docker's privileged mode.">
                                         <f:checkbox field="dockerPrivilegedMode" value="${slaveInfo.containerInfo.dockerPrivilegedMode}" checked="${slaveInfo.containerInfo.dockerPrivilegedMode}" />
                                     </f:entry>
+                                    <f:entry title="${%Docker Force Pull Image}" description="This will force a pull of the Docker Image regardless of whether it exists locally.">
+                                        <f:checkbox field="dockerForcePullImage" value="${slaveInfo.containerInfo.dockerForcePullImage}" checked="${slaveInfo.containerInfo.dockerForcePullImage}" />
+                                    </f:entry>
                                 </f:radioBlock>
                             </f:entry>
 

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -224,6 +224,7 @@ public class JenkinsSchedulerTest {
                     "docker",
                     "test-docker-in-docker-image",
                     Boolean.TRUE,
+                    Boolean.TRUE,
                     useCustomDockerCommandShell,
                     customDockerCommandShell,
                     Collections.<MesosSlaveInfo.Volume>emptyList(),


### PR DESCRIPTION
From 0.22.x Mesos implemented the force_pull_image flag but set it's default value to false. This means a 'latest' tag is ignored and the docker image is never pulled again, regardless of whether it has been updated on the docker registry.

Requires minimum Mesos 0.22.1.

Referencing these issues...
https://github.com/jenkinsci/mesos-plugin/issues/89
https://github.com/jenkinsci/mesos-plugin/issues/132