### PR TITLE
Add jenkins label to mesos slave task's name

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -53,6 +53,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 public class MesosCloud extends Cloud {
+  private static final int MAX_HOSTNAME_LENGTH = 63; // Guard against LONG hostnames - RFC-1034
   private String nativeLibraryPath;
   private String master;
   private String description;
@@ -253,7 +254,7 @@ public class MesosCloud extends Cloud {
   }
 
   private MesosSlave doProvision(int numExecutors, MesosSlaveInfo slaveInfo) throws Descriptor.FormException, IOException {
-    String name = "mesos-jenkins-" + UUID.randomUUID().toString();
+    final String name = StringUtils.abbreviate("mesos-jenkins-" + StringUtils.remove(UUID.randomUUID().toString(), '-') + "-" + slaveInfo.getLabelString(), MAX_HOSTNAME_LENGTH);
     return new MesosSlave(this, name, numExecutors, slaveInfo);
   }
 


### PR DESCRIPTION
When running many slave types, seeing everything as:

    mesos-jenkins-453c7f5c-4c70-46fa-a272-cf939852f321
    mesos-jenkins-7e2a8b6a-66e0-4cbc-87ec-cf06a4693a7e
    mesos-jenkins-06e6dd76-20e0-4b69-8fef-47d039d822f0

It becomes difficult to see what is what.

This change adds the jenkins label into the name so it looks more like this:

    mesos-foo-slave-453c7f5c-4c70-46fa-a272-cf939852f321
    mesos-bar-slave-7e2a8b6a-66e0-4cbc-87ec-cf06a4693a7e
    mesos-baz-slave-06e6dd76-20e0-4b69-8fef-47d039d822f0

where the jenkins labels are `foo-slave`, `bar-slave` and `baz-slave`