### PR TITLE
Framework roles

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
@@ -35,12 +35,15 @@ public abstract class Mesos {
     JenkinsSlave slave;
     final double cpus;
     final int mem;
+    final String role;
     final MesosSlaveInfo slaveInfo;
 
-    public SlaveRequest(JenkinsSlave slave, double cpus, int mem, MesosSlaveInfo slaveInfo) {
+    public SlaveRequest(JenkinsSlave slave, double cpus, int mem, String role,
+        MesosSlaveInfo slaveInfo) {
       this.slave = slave;
       this.cpus = cpus;
       this.mem = mem;
+      this.role = role;
       this.slaveInfo = slaveInfo;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -79,6 +79,7 @@ public class MesosCloud extends Cloud {
   private String master;
   private String description;
   private String frameworkName;
+  private String role;
   private String slavesUser;
   private String credentialsId;
   /**
@@ -149,6 +150,7 @@ public class MesosCloud extends Cloud {
       String master,
       String description,
       String frameworkName,
+      String role,
       String slavesUser,
       String principal,
       String secret,
@@ -157,8 +159,9 @@ public class MesosCloud extends Cloud {
       boolean onDemandRegistration,
       String jenkinsURL,
       String declineOfferDuration) throws NumberFormatException {
-    this("MesosCloud", nativeLibraryPath, master, description, frameworkName, slavesUser,
-         principal, secret, slaveInfos, checkpoint, onDemandRegistration, jenkinsURL);
+    this("MesosCloud", nativeLibraryPath, master, description, frameworkName, role,
+         slavesUser, principal, secret, slaveInfos, checkpoint, onDemandRegistration,
+         jenkinsURL);
   }
 
   /**
@@ -172,6 +175,7 @@ public class MesosCloud extends Cloud {
       String master,
       String description,
       String frameworkName,
+      String role,
       String slavesUser,
       String principal,
       String secret,
@@ -185,6 +189,7 @@ public class MesosCloud extends Cloud {
     this.master = master;
     this.description = description;
     this.frameworkName = frameworkName;
+    this.role = role;
     this.slavesUser = slavesUser;
     this.principal = principal;
     this.secret = secret;
@@ -214,8 +219,8 @@ public class MesosCloud extends Cloud {
    */
   public MesosCloud(@Nonnull String name, @Nonnull MesosCloud source) {
       this(name, source.nativeLibraryPath, source.master, source.description, source.frameworkName,
-           source.slavesUser, source.principal, source.secret, source.slaveInfos, source.checkpoint,
-           source.onDemandRegistration, source.jenkinsURL);
+           source.role, source.slavesUser, source.principal, source.secret, source.slaveInfos,
+           source.checkpoint, source.onDemandRegistration, source.jenkinsURL);
   }
 
   // Since MesosCloud is used as a key to a Hashmap, we need to set equals/hashcode
@@ -409,6 +414,14 @@ public class MesosCloud extends Cloud {
     this.frameworkName = frameworkName;
   }
 
+  public String getRole() {
+    return role;
+  }
+
+  public void setRole(String role) {
+    this.role = role;
+  }
+
   public String getSlavesUser() {
     return slavesUser;
   }
@@ -521,6 +534,9 @@ public class MesosCloud extends Cloud {
 
   protected Object readResolve() {
     migrateToCredentials();
+    if (role == null) {
+      role = "*";
+    }
     return this;
   }
 
@@ -605,6 +621,7 @@ public void setJenkinsURL(String jenkinsURL) {
     private String master;
     private String description;
     private String frameworkName;
+    private String role;
     private String slavesUser;
     private String principal;
     private String secret;
@@ -637,6 +654,7 @@ public void setJenkinsURL(String jenkinsURL) {
       master = object.getString("master");
       description = object.getString("description");
       frameworkName = object.getString("frameworkName");
+      role = object.getString("role");
       principal = object.getString("principal");
       secret = object.getString("secret");
       slaveAttributes = object.getString("slaveAttributes");

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
@@ -72,9 +72,10 @@ public class MesosComputerLauncher extends ComputerLauncher {
     // Create the request.
     double cpus = computer.getNode().getCpus();
     int mem = computer.getNode().getMem();
+    String role = cloud.getRole();
 
     Mesos.SlaveRequest request = new Mesos.SlaveRequest(new JenkinsSlave(name),
-        cpus, mem, computer.getNode().getSlaveInfo());
+        cpus, mem, role, computer.getNode().getSlaveInfo());
 
     // Launch the jenkins slave.
     final CountDownLatch latch = new CountDownLatch(1);

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -15,6 +15,10 @@
         <f:textbox field="frameworkName" default="Jenkins Scheduler" clazz="required"/>
     </f:entry>
 
+    <f:entry title="${%Role}">
+        <f:textbox field="role" default="*" clazz="required"/>
+    </f:entry>
+
     <f:entry title="${%Slave username}">
         <f:textbox field="slavesUser" default=""/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-role.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-role.html
@@ -1,0 +1,6 @@
+<div>
+    Specifies the resources role that Jenkins scheduler will receive offers
+    for. If role is set to "*" (default), it will receive offers for unreserved
+    resources. If role is set to something else (e.g., 'jenkins'), it will
+    receive offers for only reserved resources of the given role.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -293,7 +293,8 @@ public class JenkinsSchedulerTest {
                 null,               // externalContainerInfo,
                 containerInfo,      // containerInfo,
                 null);              //additionalURIs
-        return new Mesos.SlaveRequest(new Mesos.JenkinsSlave(TEST_JENKINS_SLAVE_NAME),0.2d,TEST_JENKINS_SLAVE_MEM,mesosSlaveInfo);
+        return new Mesos.SlaveRequest(
+            new Mesos.JenkinsSlave(TEST_JENKINS_SLAVE_NAME), 0.2d, TEST_JENKINS_SLAVE_MEM, "jenkins", mesosSlaveInfo);
     }
 
     private JenkinsScheduler.Request mockMesosRequest(


### PR DESCRIPTION
This is a fix for PR #155 and refs issue #68.

1. It accepts resources from `*` AND the specified role.
2. It launches tasks for offers with multiple sets of resources.

An example:

Given, you want to start a jenkins-slave with 4 cpus and 1024 mem.
Given, mesos sends an offer from a slave with:
* 2 cpus for role `jenkins`
* 3 cpus for role `*`
* 2048 mem for role `*`

The framework now will pick the 2 cpus for `jenkins`, 2 cpus for `*` and 1024 mem for `*` to start the task.