### PR TITLE
Run as a user inside container (p.p. seder)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -502,6 +502,15 @@ public void setJenkinsURL(String jenkinsURL) {
                   portMappings);
             }
 
+            MesosSlaveInfo.RunAsUserInfo runAsUserInfo = null;
+              if (label.has("runAsUserInfo")) {
+                JSONObject runAsUserInfoJson = label.getJSONObject("runAsUserInfo");
+                runAsUserInfo = new MesosSlaveInfo.RunAsUserInfo(
+                        runAsUserInfoJson.getString("username"),
+                        runAsUserInfoJson.getString("command")
+                        );
+            }
+
             List<MesosSlaveInfo.URI> additionalURIs = new ArrayList<MesosSlaveInfo.URI>();
             if (label.has("additionalURIs")) {
               JSONArray additionalURIsJson = label.getJSONArray("additionalURIs");
@@ -528,7 +537,8 @@ public void setJenkinsURL(String jenkinsURL) {
                 object.getString("jnlpArgs"),
                 externalContainerInfo,
                 containerInfo,
-                additionalURIs);
+                additionalURIs,
+                runAsUserInfo);
             slaveInfos.add(slaveInfo);
           }
         }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -36,6 +36,7 @@ public class MesosSlaveInfo {
   private final ContainerInfo containerInfo;
   private final List<URI> additionalURIs;
   private final Mode mode;
+  private final RunAsUserInfo runAsUserInfo;
 
   private String labelString = DEFAULT_LABEL_NAME;
 
@@ -58,7 +59,8 @@ public class MesosSlaveInfo {
       String jnlpArgs,
       ExternalContainerInfo externalContainerInfo,
       ContainerInfo containerInfo,
-      List<URI> additionalURIs)
+      List<URI> additionalURIs,
+      RunAsUserInfo runAsUserInfo)
       throws NumberFormatException {
     this.slaveCpus = Double.parseDouble(slaveCpus);
     this.slaveMem = Integer.parseInt(slaveMem);
@@ -89,6 +91,7 @@ public class MesosSlaveInfo {
         }
     }
     this.slaveAttributes = jsonObject;
+    this.runAsUserInfo = runAsUserInfo;
   }
 
   public String getLabelString() {
@@ -151,7 +154,11 @@ public class MesosSlaveInfo {
     return additionalURIs;
   }
 
-  /**
+  public RunAsUserInfo getRunAsUserInfo() {
+    return runAsUserInfo;
+  }
+
+    /**
    * Removes any additional {@code -Xmx} JVM args from the provided JVM
    * arguments. This is to ensure that the logic that sets the maximum heap
    * sized based on the memory available to the slave is not overriden by a
@@ -183,6 +190,28 @@ public class MesosSlaveInfo {
     public String getImage() {
       return image;
     }
+  }
+
+  public static class RunAsUserInfo {
+      public  final static String TOKEN_USERNAME = "{USERNAME}";
+      public  final static String TOKEN_SLAVE_COMMAND = "{SLAVE_CMD}";
+
+      private final String username;
+      private final String command;
+
+      @DataBoundConstructor
+      public RunAsUserInfo(String username, String command) {
+          this.username = username;
+          this.command = command;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+      public String getCommand() {
+          return command;
+      }
   }
 
   public static class ContainerInfo {

--- a/src/main/java/org/jenkinsci/plugins/mesos/listener/MesosRunListener.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/listener/MesosRunListener.java
@@ -18,19 +18,19 @@ import org.jenkinsci.plugins.mesos.MesosSlave;
 public class MesosRunListener extends RunListener<Run> {
 
   private static final Logger LOGGER = Logger.getLogger(MesosRunListener.class.getName());
-  
+
   public MesosRunListener() {
-    
+
   }
-  
+
   /**
    * @param targetType
    */
   @SuppressWarnings("unchecked")
   public MesosRunListener(Class targetType) {
-    super(targetType);    
+    super(targetType);
   }
-  
+
   /**
    * Prints the actual Hostname where Mesos slave is provisioned in console output.
    * This would help us debug/take action if build fails in that slave.

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -95,6 +95,15 @@
                         <f:textbox field="jnlpArgs" default="" value="${slaveInfo.jnlpArgs}"/>
                     </f:entry>
 
+                    <f:optionalBlock title="${%Run as User}" name="runAsUserInfo" checked="${slaveInfo.runAsUserInfo != null}">
+                        <f:entry title="${%Username}">
+                            <f:textbox clazz="required" field="username" default="${slaveInfo.runAsUserInfo.DEFAULT_USERNAME}" value="${slaveInfo.runAsUserInfo.username}" />
+                        </f:entry>
+                        <f:entry title="${%Command}">
+                            <f:textbox clazz="required" field="command" default="${slaveInfo.runAsUserInfo.DEFAULT_COMMAND}" value="${slaveInfo.runAsUserInfo.command}" />
+                        </f:entry>
+                    </f:optionalBlock>
+
                     <f:advanced>
                         <f:optionalBlock title="${%Use Docker Containerizer}" name="containerInfo" checked="${slaveInfo.containerInfo != null}">
 

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -158,7 +158,8 @@ public class JenkinsSchedulerTest {
                 TEST_JENKINS_SLAVE_MEM,
                 TEST_JENKINS_SLAVE_ARG,
                 TEST_JENKINS_JNLP_ARG,
-                TEST_JENKINS_SLAVE_NAME);
+                TEST_JENKINS_SLAVE_NAME,
+                null);
         assertEquals("jenkins command to run should be specified as value", jenkinsCommand2Run, commandInfo.getValue());
         assertEquals("mesos command should have no args specified by default", 0, commandInfo.getArgumentsCount());
     }
@@ -175,7 +176,8 @@ public class JenkinsSchedulerTest {
                 TEST_JENKINS_SLAVE_MEM,
                 TEST_JENKINS_SLAVE_ARG,
                 TEST_JENKINS_JNLP_ARG,
-                TEST_JENKINS_SLAVE_NAME);
+                TEST_JENKINS_SLAVE_NAME,
+                null);
         assertEquals("jenkins command to run should be specified as value", jenkinsCommand2Run, commandInfo.getValue());
         assertEquals("mesos command should have no args specified by default", 0, commandInfo.getArgumentsCount());
     }
@@ -193,7 +195,8 @@ public class JenkinsSchedulerTest {
                 TEST_JENKINS_SLAVE_MEM,
                 TEST_JENKINS_SLAVE_ARG,
                 TEST_JENKINS_JNLP_ARG,
-                TEST_JENKINS_SLAVE_NAME);
+                TEST_JENKINS_SLAVE_NAME,
+                null);
 
         assertEquals("args should now consist of the single original command ", 1, commandInfo.getArgumentsCount());
         assertEquals("args should now consist of the original command ", jenkinsCommand2Run, commandInfo.getArguments(0));
@@ -248,7 +251,9 @@ public class JenkinsSchedulerTest {
                 null,               //jnlpArgs,
                 null,               // externalContainerInfo,
                 containerInfo,      // containerInfo,
-                null);              //additionalURIs
+                null,               //additionalURIs
+                null                // runAsUserInfo
+                );
         Mesos.SlaveRequest slaveReq = new Mesos.SlaveRequest(new Mesos.JenkinsSlave(TEST_JENKINS_SLAVE_NAME),0.2d,TEST_JENKINS_SLAVE_MEM,mesosSlaveInfo);
         Mesos.SlaveResult slaveResult = Mockito.mock(Mesos.SlaveResult.class);
 


### PR DESCRIPTION
Needed this change to actually run our setup scripts within our docker containers as different users. We know this is a workaround, however - it served our purpose.

PS: The cmd / username used needs to be of special syntax (see commit). 
