### PR TITLE
[JENKINS-30741] - Support the creation on NonModifyableCloudConfigs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -38,6 +38,7 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
 
 import javax.servlet.ServletException;
 
@@ -124,7 +125,29 @@ public class MesosCloud extends Cloud {
       boolean checkpoint,
       boolean onDemandRegistration,
       String jenkinsURL) throws NumberFormatException {
-    super("MesosCloud");
+    this("MesosCloud", nativeLibraryPath, master, description, frameworkName, slavesUser, 
+            principal, secret, slaveInfos, checkpoint, onDemandRegistration, jenkinsURL);
+  }
+  
+  /**
+   * Constructor, which also allows to specify a custom name.
+   * @throws NumberFormatException Numeric parameter parsing error
+   * @since TODO
+   */
+  protected MesosCloud(
+      String cloudName,
+      String nativeLibraryPath,
+      String master,
+      String description,
+      String frameworkName,
+      String slavesUser,
+      String principal,
+      String secret,
+      List<MesosSlaveInfo> slaveInfos,
+      boolean checkpoint,
+      boolean onDemandRegistration,
+      String jenkinsURL) throws NumberFormatException {
+    super(cloudName);
 
     this.nativeLibraryPath = nativeLibraryPath;
     this.master = master;
@@ -147,6 +170,20 @@ public class MesosCloud extends Cloud {
     }
   }
 
+  /**
+   * Copy constructor.
+   * Allows to create copies of the original mesos cloud. Since it's a singleton
+   * by design, this method also allows specifying a new name.
+   * @param name Name of the cloud to be created
+   * @param source Source Mesos cloud implementation
+   * @since TODO
+   */
+  public MesosCloud(@Nonnull String name, @Nonnull MesosCloud source) {
+      this(name, source.nativeLibraryPath, source.master, source.description, source.frameworkName,
+           source.slavesUser, source.principal, source.secret, source.slaveInfos, source.checkpoint,
+           source.onDemandRegistration, source.jenkinsURL);
+  }
+          
   // Since MesosCloud is used as a key to a Hashmap, we need to set equals/hashcode
   // or lookups won't work if any fields are changed.  Use master string as the key since
   // the rest of this code assumes it is unique among the Cloud objects.

--- a/src/main/java/org/jenkinsci/plugins/mesos/NonConfigurableMesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/NonConfigurableMesosCloud.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 CloudBees, Inc. and other contributors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jenkinsci.plugins.mesos;
+
+import hudson.Extension;
+import hudson.slaves.Cloud;
+import java.util.List;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ * Mesos {@link Cloud}, which cannot be reconfigured from the web interface.
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+public class NonConfigurableMesosCloud extends MesosCloud {
+ 
+    /**
+     * Constructs a cloud from a parent Mesos Cloud
+     * @param name Name of the cloud to be created
+     */
+    public NonConfigurableMesosCloud(String name, String nativeLibraryPath, String master, String description, 
+            String frameworkName, String slavesUser, String principal, String secret, 
+            List<MesosSlaveInfo> slaveInfos, boolean checkpoint, boolean onDemandRegistration, String jenkinsURL) 
+            throws NumberFormatException {
+        super(name, nativeLibraryPath, master, description, frameworkName, slavesUser, 
+                principal, secret, slaveInfos, checkpoint, onDemandRegistration, jenkinsURL);
+    }
+    
+    /**
+     * Copy constructor.
+     * @param name Name of the cloud to be created.
+     * @param cloud Cloud to be copied
+     */
+    public NonConfigurableMesosCloud(String name, MesosCloud cloud) {
+        super(name, cloud);
+    }
+    
+    @Extension
+    public static class DescriptorImpl extends MesosCloud.DescriptorImpl {
+        @Override
+        public String getDisplayName() {
+            return Messages.NonConfigurableMesosCloud_displayName();
+        }
+
+        @Override
+        public boolean configure(StaplerRequest request, JSONObject object) throws FormException {
+            return true;
+        }
+        
+        @Override
+        public Cloud newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            // TODO: replace by getActieInstance in 1.590+
+            final Jenkins jenkins = Jenkins.getInstance();
+            if (jenkins == null) {
+                throw new IllegalStateException("Jenkins instance is not ready");
+            }
+            
+            // We prevent the cloud reconfiguration from the web UI
+            String cloudName = req.getParameter("cloudName");
+            return jenkins.getCloud(cloudName);
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/mesos/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/Messages.properties
@@ -1,2 +1,4 @@
 SingleUseCause=Single-use slave has already been used and is pending removal.
 DeletedCause=The slave is offline and is pending removal.
+
+NonConfigurableMesosCloud.displayName=Mesos Cloud (predefined settings)

--- a/src/main/resources/org/jenkinsci/plugins/mesos/NonConfigurableMesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/NonConfigurableMesosCloud/config.jelly
@@ -5,14 +5,4 @@
     <f:readOnlyTextbox  name="cloudName" value="${instance.displayName}"/>
   </f:entry>
   
-  <!-- Some read-only contents 
-    - TODO: Rework the layout to show the informative info: supported labels, etc.
-  -->
-  <f:entry title="${%Mesos Master [hostname:port]}" field="master">
-    <f:readOnlyTextbox field="master" clazz="required"/>
-  </f:entry>
-  <f:entry title="${%Description}">
-    <f:readOnlyTextbox field="description" />
-  </f:entry>
-  
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/NonConfigurableMesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/NonConfigurableMesosCloud/config.jelly
@@ -1,0 +1,18 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  
+  <f:entry title="${%Cloud name}">
+    <f:readOnlyTextbox  name="cloudName" value="${instance.displayName}"/>
+  </f:entry>
+  
+  <!-- Some read-only contents 
+    - TODO: Rework the layout to show the informative info: supported labels, etc.
+  -->
+  <f:entry title="${%Mesos Master [hostname:port]}" field="master">
+    <f:readOnlyTextbox field="master" clazz="required"/>
+  </f:entry>
+  <f:entry title="${%Description}">
+    <f:readOnlyTextbox field="description" />
+  </f:entry>
+  
+</j:jelly>


### PR DESCRIPTION
On a multi-instanceJenkins infrastructure we sometimes need to provide an alternate implementation of MesosCloud, which would hide the most of configs from local administrators.

It would be great to have a generic MesosCloud implementation, which takes a configuration and then hides parameters from users and prevents their configuration from UIs.

https://issues.jenkins-ci.org/browse/JENKINS-30741

@reviewbybees 