### PR TITLE
Allow running all jobs in mesos slaves

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -272,9 +272,9 @@ public class MesosCloud extends Cloud {
     // item in the list of configured Mesos labels.
     // TODO(vinod): The framework may not have the resources necessary
     // to start a task when it comes time to launch the slave.
-    if (label != null && slaveInfos != null) {
+    if (slaveInfos != null) {
       for (MesosSlaveInfo slaveInfo : slaveInfos) {
-        if (label.matches(Label.parse(slaveInfo.getLabelString()))) {
+        if (slaveInfo.matchesLabel(label)) {
           return true;
         }
       }
@@ -365,7 +365,7 @@ public class MesosCloud extends Cloud {
   private MesosSlaveInfo getSlaveInfo(List<MesosSlaveInfo> slaveInfos,
       Label label) {
     for (MesosSlaveInfo slaveInfo : slaveInfos) {
-      if (label.matches(Label.parse(slaveInfo.getLabelString()))) {
+      if (slaveInfo.matchesLabel(label)) {
         return slaveInfo;
       }
     }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -169,10 +169,10 @@ public class MesosSlaveInfo {
   }
 
   /**
-   * Check if the label in the slave matches the provided label, either both are null or are the same
+   * Check if the label in the slave matches the provided label, either both are null or are the same.
    * 
    * @param label
-   * @return whether the slave label matches
+   * @return Whether the slave label matches.
    */
   public boolean matchesLabel(@CheckForNull Label label) {
     return ((label == null) && (getLabelString() == null))

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -4,15 +4,12 @@ import hudson.model.Descriptor.FormException;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Logger;
 
 import javax.annotation.CheckForNull;
 
 import hudson.model.Label;
-import hudson.model.Node;
 import hudson.model.Node.Mode;
-import hudson.model.labels.LabelAtom;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -4,11 +4,15 @@ import hudson.model.Descriptor.FormException;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
 
+import javax.annotation.CheckForNull;
+
+import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Node.Mode;
-
+import hudson.model.labels.LabelAtom;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
@@ -37,6 +41,7 @@ public class MesosSlaveInfo {
   private final List<URI> additionalURIs;
   private final Mode mode;
 
+  @CheckForNull
   private String labelString = DEFAULT_LABEL_NAME;
 
   private static final Logger LOGGER = Logger.getLogger(MesosSlaveInfo.class
@@ -68,8 +73,7 @@ public class MesosSlaveInfo {
     this.remoteFSRoot = StringUtils.isNotBlank(remoteFSRoot) ? remoteFSRoot
         .trim() : "jenkins";
     this.idleTerminationMinutes = Integer.parseInt(idleTerminationMinutes);
-    this.labelString = StringUtils.isNotBlank(labelString) ? labelString
-        : DEFAULT_LABEL_NAME;
+    this.labelString = StringUtils.isNotBlank(labelString) ? labelString : null;
     this.mode = mode != null ? mode : Mode.NORMAL;
     this.jvmArgs = StringUtils.isNotBlank(jvmArgs) ? cleanseJvmArgs(jvmArgs)
         : DEFAULT_JVM_ARGS;
@@ -91,6 +95,7 @@ public class MesosSlaveInfo {
     this.slaveAttributes = jsonObject;
   }
 
+  @CheckForNull
   public String getLabelString() {
     return labelString;
   }
@@ -164,6 +169,17 @@ public class MesosSlaveInfo {
    */
   private String cleanseJvmArgs(final String jvmArgs) {
     return jvmArgs.replaceAll(JVM_ARGS_PATTERN, "");
+  }
+
+  /**
+   * Check if the label in the slave matches the provided label, either both are null or are the same
+   * 
+   * @param label
+   * @return whether the slave label matches
+   */
+  public boolean matchesLabel(@CheckForNull Label label) {
+    return ((label == null) && (getLabelString() == null))
+      || (getLabelString() != null && label != null && label.matches(Label.parse(getLabelString())));
   }
 
   public static class ExternalContainerInfo {


### PR DESCRIPTION
If label is empty then mesos slaves will be used for all jobs without label requirements

In a mesos-only Jenkins installation it is confusing for users to create jobs
that sit there because the label is by default empty and never get scheduled in Mesos.
If the Jenkins config for mesos cloud has an empty label then the mesos slaves
are added to the default pool for any job without label requirements

@reviewbybees 