### PR TITLE
Integration with credentials plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
 
   <dependencies>
       <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>credentials</artifactId>
+          <version>1.22</version>
+      </dependency>
+      <dependency>
           <groupId>org.apache.mesos</groupId>
           <artifactId>mesos</artifactId>
           <version>${mesos.version}</version>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -1,4 +1,4 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry title="Mesos native library path" field="nativeLibraryPath">
         <f:textbox field="nativeLibraryPath" clazz="required"/>
     </f:entry>
@@ -19,12 +19,8 @@
         <f:textbox field="slavesUser" default=""/>
     </f:entry>
 
-    <f:entry title="${%Framework Principal}" field="principal">
-      <f:textbox field="principal" default="jenkins" />
-    </f:entry>
-
-    <f:entry title="${%Framework Secret}" field="secret" description="${%Specify secret to enable framework authentication}">
-      <f:textbox field="secret"/>
+    <f:entry field="credentialsId" title="${%Framework credentials}">
+        <c:select/>
     </f:entry>
 
     <f:entry title="${%Jenkins URL }" field="jenkinsURL">

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-credentialsId.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-credentialsId.html
@@ -1,0 +1,3 @@
+<div>
+    The credentials to use to register as a Mesos framework. If none is provided, then the principal <i>jenkins</i> and an empty secret will be used.
+</div>


### PR DESCRIPTION
This pull request provides integration with credentials plugin to replace framework principal/secret.

Credentials plugin provides a central facility to manage credentials and to update them only once if needed.

The motivation for this change is to provide the ability to update programmatically the mesos credentials without touching the cloud configuration, which may have been altered by an administrator. The current implementation doesn't allow that in an easy way, as you need to post the whole configuration.