### PR TITLE
Wrap JenkinsScheduler run body in a try/catch/finally.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -114,42 +114,46 @@ public class JenkinsScheduler implements Scheduler {
     new Thread(new Runnable() {
       @Override
       public void run() {
-        String targetUser = mesosCloud.getSlavesUser();
-        String webUrl = Jenkins.getInstance().getRootUrl();
-        if (webUrl == null) webUrl = System.getenv("JENKINS_URL");
-        // Have Mesos fill in the current user.
-        FrameworkInfo framework = FrameworkInfo.newBuilder()
-          .setUser(targetUser == null ? "" : targetUser)
-          .setName(mesosCloud.getFrameworkName())
-          .setPrincipal(mesosCloud.getPrincipal())
-          .setCheckpoint(mesosCloud.isCheckpoint())
-          .setWebuiUrl(webUrl != null ? webUrl :  "")
-          .build();
+        try {
+            String targetUser = mesosCloud.getSlavesUser();
+            String webUrl = Jenkins.getInstance().getRootUrl();
+            if (webUrl == null) webUrl = System.getenv("JENKINS_URL");
+            // Have Mesos fill in the current user.
+            FrameworkInfo framework = FrameworkInfo.newBuilder()
+                    .setUser(targetUser == null ? "" : targetUser)
+                    .setName(mesosCloud.getFrameworkName())
+                    .setPrincipal(mesosCloud.getPrincipal())
+                    .setCheckpoint(mesosCloud.isCheckpoint())
+                    .setWebuiUrl(webUrl != null ? webUrl : "")
+                    .build();
 
-        LOGGER.info("Initializing the Mesos driver with options"
-        + "\n" + "Framework Name: " + framework.getName()
-        + "\n" + "Principal: " + framework.getPrincipal()
-        + "\n" + "Checkpointing: " + framework.getCheckpoint()
-        );
+            LOGGER.info("Initializing the Mesos driver with options"
+                            + "\n" + "Framework Name: " + framework.getName()
+                            + "\n" + "Principal: " + framework.getPrincipal()
+                            + "\n" + "Checkpointing: " + framework.getCheckpoint()
+            );
 
-        if (StringUtils.isNotBlank(mesosCloud.getSecret())) {
-            Credential credential = Credential.newBuilder()
-              .setPrincipal(mesosCloud.getPrincipal())
-              .setSecret(ByteString.copyFromUtf8(mesosCloud.getSecret()))
-              .build();
+            if (StringUtils.isNotBlank(mesosCloud.getSecret())) {
+                Credential credential = Credential.newBuilder()
+                        .setPrincipal(mesosCloud.getPrincipal())
+                        .setSecret(ByteString.copyFromUtf8(mesosCloud.getSecret()))
+                        .build();
 
-            LOGGER.info("Authenticating with Mesos master with principal " + credential.getPrincipal());
-            driver = new MesosSchedulerDriver(JenkinsScheduler.this, framework, mesosCloud.getMaster(), credential);
-        } else {
-            driver = new MesosSchedulerDriver(JenkinsScheduler.this, framework, mesosCloud.getMaster());
+                LOGGER.info("Authenticating with Mesos master with principal " + credential.getPrincipal());
+                driver = new MesosSchedulerDriver(JenkinsScheduler.this, framework, mesosCloud.getMaster(), credential);
+            } else {
+                driver = new MesosSchedulerDriver(JenkinsScheduler.this, framework, mesosCloud.getMaster());
+            }
+            Status runStatus = driver.run();
+            if (runStatus != Status.DRIVER_STOPPED) {
+                LOGGER.severe("The Mesos driver was aborted! Status code: " + runStatus.getNumber());
+            }
+        } catch(RuntimeException e) {
+            LOGGER.log(Level.SEVERE, "Caught a RuntimeException", e);
+        } finally {
+            driver = null;
+            running = false;
         }
-        Status runStatus = driver.run();
-        if (runStatus != Status.DRIVER_STOPPED) {
-          LOGGER.severe("The Mesos driver was aborted! Status code: " + runStatus.getNumber());
-        }
-
-        driver = null;
-        running = false;
       }
     }).start();
   }

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -151,6 +151,9 @@ public class JenkinsScheduler implements Scheduler {
         } catch(RuntimeException e) {
             LOGGER.log(Level.SEVERE, "Caught a RuntimeException", e);
         } finally {
+            if (driver != null) {
+                driver.abort();
+            }
             driver = null;
             running = false;
         }


### PR DESCRIPTION
Split from #179 

If any RuntimeException is raised during Scheduler execution, the object
was left in a corrupt state with running == true and driver != null.

The previous implementation would let any RuntimeException kill the
thread without any trace of it. Now, it is properly logged when it
happens and leave the scheduler in a correct state.

@reviewbybees 