### PR TITLE
Modify JenkinsScheduler#findPortsToUse to return a SortedSet structure instead of a List.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -402,8 +402,8 @@ public class JenkinsScheduler implements Scheduler {
   }
 
   @VisibleForTesting
-  SortedSet<Integer> findPortsToUse(Offer offer, int maxCount) {
-      SortedSet<Integer> portsToUse = new TreeSet<Integer>();
+  SortedSet<Long> findPortsToUse(Offer offer, int maxCount) {
+      SortedSet<Long> portsToUse = new TreeSet<Long>();
       List<Value.Range> portRangesList = null;
 
       // Locate the port resource in the offer
@@ -424,9 +424,9 @@ public class JenkinsScheduler implements Scheduler {
       // Check this port range for ports that we can use
       for (Value.Range currentPortRange : portRangesList) {
         // Check each port until we reach the end of the current range
-        int begin = (int) currentPortRange.getBegin();
+        long begin = currentPortRange.getBegin();
         long end = currentPortRange.getEnd();
-        for (int candidatePort = begin; candidatePort <= end && portsToUse.size() < maxCount; candidatePort++) {
+        for (long candidatePort = begin; candidatePort <= end && portsToUse.size() < maxCount; candidatePort++) {
             portsToUse.add(candidatePort);
         }
       }
@@ -570,8 +570,8 @@ public class JenkinsScheduler implements Scheduler {
 
           if (request.request.slaveInfo.getContainerInfo().hasPortMappings()) {
               List<MesosSlaveInfo.PortMapping> portMappings = request.request.slaveInfo.getContainerInfo().getPortMappings();
-              Set<Integer> portsToUse = findPortsToUse(offer, portMappings.size());
-              Iterator<Integer> iterator = portsToUse.iterator();
+              Set<Long> portsToUse = findPortsToUse(offer, portMappings.size());
+              Iterator<Long> iterator = portsToUse.iterator();
               Value.Ranges.Builder portRangesBuilder = Value.Ranges.newBuilder();
 
               for (MesosSlaveInfo.PortMapping portMapping : portMappings) {
@@ -579,9 +579,9 @@ public class JenkinsScheduler implements Scheduler {
                           .setContainerPort(portMapping.getContainerPort()) //
                           .setProtocol(portMapping.getProtocol());
 
-                  int portToUse = portMapping.getHostPort() == null ? iterator.next() : portMapping.getHostPort();
+                  Long portToUse = portMapping.getHostPort() == null ? iterator.next() : portMapping.getHostPort();
 
-                  portMappingBuilder.setHostPort(portToUse);
+                  portMappingBuilder.setHostPort(portToUse.intValue());
 
                   portRangesBuilder.addRange(
                     Value.Range

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -82,9 +82,9 @@ public class JenkinsSchedulerTest {
 
         executorService.shutdown();
 
-        // Test that there is no infinite loop by asserting that the task finishes in 500ms or less
+        // Test that there is no infinite loop
         try {
-            assertTrue(executorService.awaitTermination(500L, TimeUnit.MILLISECONDS));
+            assertTrue(executorService.awaitTermination(2L, TimeUnit.SECONDS));
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } finally {
@@ -138,9 +138,9 @@ public class JenkinsSchedulerTest {
 
         executorService.shutdown();
 
-        // Test that there is no infinite loop by asserting that the task finishes in 500ms or less
+        // Test that there is no infinite loop
         try {
-            assertTrue(executorService.awaitTermination(999999500L, TimeUnit.MILLISECONDS));
+            assertTrue(executorService.awaitTermination(2L, TimeUnit.SECONDS));
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } finally {

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -15,7 +15,9 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Collections;
-import java.util.List;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.SortedSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -57,10 +59,10 @@ public class JenkinsSchedulerTest {
     public void testFindPortsToUse() {
         Protos.Offer offer = createOfferWithVariableRanges(31000, 32000);
 
-        List<Integer> portsToUse = jenkinsScheduler.findPortsToUse(offer, 1);
+        Set<Integer> portsToUse = jenkinsScheduler.findPortsToUse(offer, 1);
 
         assertEquals(1, portsToUse.size());
-        assertEquals(Integer.valueOf(31000), portsToUse.get(0));
+        assertEquals(Integer.valueOf(31000), portsToUse.iterator().next());
     }
 
     @Test
@@ -71,10 +73,10 @@ public class JenkinsSchedulerTest {
             public void run() {
                 Protos.Offer offer = createOfferWithVariableRanges(31000, 31000);
 
-                List<Integer> portsToUse = jenkinsScheduler.findPortsToUse(offer, 1);
+                Set<Integer> portsToUse = jenkinsScheduler.findPortsToUse(offer, 1);
 
                 assertEquals(1, portsToUse.size());
-                assertEquals(Integer.valueOf(31000), portsToUse.get(0));
+                assertEquals(Integer.valueOf(31000), portsToUse.iterator().next());
             }
         });
 
@@ -125,11 +127,12 @@ public class JenkinsSchedulerTest {
         executorService.execute(new Runnable() {
             @Override
             public void run() {
-                List<Integer> portsToUse = jenkinsScheduler.findPortsToUse(protoOffer, 2);
+                SortedSet<Integer> portsToUse = jenkinsScheduler.findPortsToUse(protoOffer, 2);
 
                 assertEquals(2, portsToUse.size());
-                assertEquals(Integer.valueOf(31000), portsToUse.get(0));
-                assertEquals(Integer.valueOf(31005), portsToUse.get(1));
+                Iterator<Integer> iterator = portsToUse.iterator();
+                assertEquals(Integer.valueOf(31000), iterator.next());
+                assertEquals(Integer.valueOf(31005), iterator.next());
             }
         });
 

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -59,10 +59,10 @@ public class JenkinsSchedulerTest {
     public void testFindPortsToUse() {
         Protos.Offer offer = createOfferWithVariableRanges(31000, 32000);
 
-        Set<Integer> portsToUse = jenkinsScheduler.findPortsToUse(offer, 1);
+        Set<Long> portsToUse = jenkinsScheduler.findPortsToUse(offer, 1);
 
         assertEquals(1, portsToUse.size());
-        assertEquals(Integer.valueOf(31000), portsToUse.iterator().next());
+        assertEquals(Long.valueOf(31000), portsToUse.iterator().next());
     }
 
     @Test
@@ -73,10 +73,10 @@ public class JenkinsSchedulerTest {
             public void run() {
                 Protos.Offer offer = createOfferWithVariableRanges(31000, 31000);
 
-                Set<Integer> portsToUse = jenkinsScheduler.findPortsToUse(offer, 1);
+                Set<Long> portsToUse = jenkinsScheduler.findPortsToUse(offer, 1);
 
                 assertEquals(1, portsToUse.size());
-                assertEquals(Integer.valueOf(31000), portsToUse.iterator().next());
+                assertEquals(Long.valueOf(31000), portsToUse.iterator().next());
             }
         });
 
@@ -127,12 +127,12 @@ public class JenkinsSchedulerTest {
         executorService.execute(new Runnable() {
             @Override
             public void run() {
-                SortedSet<Integer> portsToUse = jenkinsScheduler.findPortsToUse(protoOffer, 2);
+                SortedSet<Long> portsToUse = jenkinsScheduler.findPortsToUse(protoOffer, 2);
 
                 assertEquals(2, portsToUse.size());
-                Iterator<Integer> iterator = portsToUse.iterator();
-                assertEquals(Integer.valueOf(31000), iterator.next());
-                assertEquals(Integer.valueOf(31005), iterator.next());
+                Iterator<Long> iterator = portsToUse.iterator();
+                assertEquals(Long.valueOf(31000), iterator.next());
+                assertEquals(Long.valueOf(31005), iterator.next());
             }
         });
 


### PR DESCRIPTION
This ensures port order is deterministic and should prevent any flaky behaviour for testing.

e.g. https://jenkins.ci.cloudbees.com/job/plugins/job/mesos-plugin/org.jenkins-ci.plugins$mesos/324/testReport/junit/org.jenkinsci.plugins.mesos/JenkinsSchedulerTest/testFindPortsToUseSamePortNumber/

@reviewbybees 
