### PR TITLE
Set _JAVA_OPTIONS to use the executor memory as max heap

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -22,6 +22,7 @@ import hudson.model.Hudson;
 import hudson.model.Slave;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.ComputerLauncher;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -55,7 +56,8 @@ public class MesosSlave extends Slave {
     this.slaveInfo = slaveInfo;
     this.cpus = slaveInfo.getSlaveCpus() + (numExecutors * slaveInfo.getExecutorCpus());
     this.mem = slaveInfo.getSlaveMem() + (numExecutors * slaveInfo.getExecutorMem());
-
+    EnvironmentVariablesNodeProperty.Entry entry = new EnvironmentVariablesNodeProperty.Entry("_JAVA_OPTIONS", "-Xmx"+slaveInfo.getExecutorMem()+"m");
+    getNodeProperties().add(new EnvironmentVariablesNodeProperty(entry));
     LOGGER.info("Constructing Mesos slave " + name + " from cloud " + cloud.getDescription());
   }
 


### PR DESCRIPTION
Recent JVMs determine automatically the max heap by taking about 1/4
of the available memory.

http://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/parallel.html#default_heap_size

The problem is that it takes as reference the host memory through
RLIMIT_AS flag value, and not the value defined by the cgroup it belongs
to.

As a consequence, if -Xmx is not explicitely specified and set to
relevant value, build processes may get killed by OOM-killer.

This takes the executor memory and set it as maximum heap size for any
forked jvm process which is what the user wants in most cases.