### PR TITLE
Remove useless call to dependency-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,24 +141,6 @@
   <build>
       <plugins>
           <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-dependency-plugin</artifactId>
-              <executions>
-                  <execution>
-                      <id>copy-dependencies</id>
-                      <phase>package</phase>
-                      <goals>
-                          <goal>copy-dependencies</goal>
-                      </goals>
-                      <configuration>
-                          <outputDirectory>${project.build.directory}</outputDirectory>
-                          <overWriteReleases>false</overWriteReleases>
-                          <overWriteSnapshots>true</overWriteSnapshots>
-                      </configuration>
-                  </execution>
-              </executions>
-          </plugin>
-          <plugin>
               <artifactId>maven-compiler-plugin</artifactId>
               <configuration>
                   <target>1.6</target>


### PR DESCRIPTION
This has no practical use and clutters target/ folder.