### PR TITLE
Update jenkins slave naming to fix issues with spaces

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -343,12 +343,12 @@ public class MesosCloud extends Cloud {
     if (slaveInfo.getLabelString() == null) {
       return StringUtils.EMPTY;
     } else {
-      return "-" + slaveInfo.getLabelString();
+      return StringUtils.remove("-" + slaveInfo.getLabelString(), " ");
     }
   }
 
   private MesosSlave doProvision(int numExecutors, MesosSlaveInfo slaveInfo) throws Descriptor.FormException, IOException {
-    final String name = StringUtils.abbreviate("mesos-jenkins-" + StringUtils.remove(UUID.randomUUID().toString(), '-') + dashLabel(slaveInfo), MAX_HOSTNAME_LENGTH);
+    final String name = StringUtils.left("mesos-jenkins-" + StringUtils.remove(UUID.randomUUID().toString(), '-') + dashLabel(slaveInfo), MAX_HOSTNAME_LENGTH);
     return new MesosSlave(this, name, numExecutors, slaveInfo);
   }
 


### PR DESCRIPTION
When jenkins slaves have multiple labels, there are spaces between the labels.  When this is translated directly into the mesos jenkins slave name it causes problems:

- When running slave.jar, jenkins does not enclose the name in quotes, so if there are spaces they are treated as separate command line parameters and this causes the java command to fail
- The mesos jenkins slave name is translated directly into a path so spaces and the ellipsis at the end make for difficult paths to work with.

This change removes any spaces from the label string and uses "left" instead of "abbreviate" to truncate the jenkins slave name to 63 characters instead of abbreviating it with an ellipsis.