### PR TITLE
getCredentials should return null if credentialsId is null

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -289,13 +289,17 @@ public class MesosCloud extends Cloud {
    * if there is no credentials associated with the given id.
    */
   public StandardUsernamePasswordCredentials getCredentials() {
-    List<DomainRequirement> domainRequirements = (master == null) ? Collections.<DomainRequirement>emptyList()
-      : URIRequirementBuilder.fromUri(master.trim()).build();
-    Jenkins jenkins = Jenkins.getInstance();
-    return CredentialsMatchers.firstOrNull(CredentialsProvider
-      .lookupCredentials(StandardUsernamePasswordCredentials.class, jenkins, ACL.SYSTEM, domainRequirements),
-      CredentialsMatchers.withId(credentialsId)
-    );
+    if (credentialsId == null) {
+      return null;
+    } else {
+      List<DomainRequirement> domainRequirements = (master == null) ? Collections.<DomainRequirement>emptyList()
+              : URIRequirementBuilder.fromUri(master.trim()).build();
+      Jenkins jenkins = Jenkins.getInstance();
+      return CredentialsMatchers.firstOrNull(CredentialsProvider
+                      .lookupCredentials(StandardUsernamePasswordCredentials.class, jenkins, ACL.SYSTEM, domainRequirements),
+              CredentialsMatchers.withId(credentialsId)
+      );
+    }
   }
 
   @Override


### PR DESCRIPTION
Otherwise, will throw a NPE

```
java.lang.NullPointerException
	at com.cloudbees.plugins.credentials.matchers.IdMatcher.<init>(IdMatcher.java:49)
	at com.cloudbees.plugins.credentials.CredentialsMatchers.withId(CredentialsMatchers.java:112)
	at org.jenkinsci.plugins.mesos.MesosCloud.getCredentials(MesosCloud.java:298)
	at org.jenkinsci.plugins.mesos.JenkinsScheduler$1.run(JenkinsScheduler.java:127)
	at java.lang.Thread.run(Thread.java:745)
```