### PR TITLE
Fix getSlaveAttributeForLabel when labelName is null

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -517,14 +517,8 @@ public class MesosCloud extends Cloud {
 
   public JSONObject getSlaveAttributeForLabel(String labelName) {
     for (MesosSlaveInfo slaveInfo : slaveInfos) {
-      if(labelName != null) {
-        if (labelName.equals(slaveInfo.getLabelString())) {
+      if (StringUtils.equals(labelName, slaveInfo.getLabelString())) {
           return slaveInfo.getSlaveAttributes();
-        }
-      } else {
-        if (slaveInfo.getLabelString() == null) {
-          return slaveInfo.getSlaveAttributes();
-        }
       }
     }
     return null;

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -516,9 +516,13 @@ public class MesosCloud extends Cloud {
   */
 
   public JSONObject getSlaveAttributeForLabel(String labelName) {
-    if(labelName!=null) {
-      for (MesosSlaveInfo slaveInfo : slaveInfos) {
+    for (MesosSlaveInfo slaveInfo : slaveInfos) {
+      if(labelName != null) {
         if (labelName.equals(slaveInfo.getLabelString())) {
+          return slaveInfo.getSlaveAttributes();
+        }
+      } else {
+        if (slaveInfo.getLabelString() == null) {
           return slaveInfo.getSlaveAttributes();
         }
       }


### PR DESCRIPTION
Return slave attributes of a slave with no label (instead of null) when the request is for a slave with no label.