### PR TITLE
Slaves should not try to reconnect

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -98,7 +98,7 @@
                     </f:entry>
 
                     <f:entry title="${%Additional Jenkins Slave Agent JNLP arguments}" field="jnlpArgs">
-                        <f:textbox field="jnlpArgs" default="" value="${slaveInfo.jnlpArgs}"/>
+                        <f:textbox field="jnlpArgs" default="-noReconnect" value="${slaveInfo.jnlpArgs}"/>
                     </f:entry>
 
                     <f:advanced>


### PR DESCRIPTION
We have seen instances where the slave info is deleted from the master and the slave keeps running forever
probably due to some race condition
Default to no reconnect, but can be overriden

@reviewbybees 