### PR TITLE
Update mesos dependency to 0.27.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <jenkins.version>1.565.3</jenkins.version>
     <jenkins-test-harness.version>1.565.3</jenkins-test-harness.version>
     <findbugs.failOnError>false</findbugs.failOnError>
-    <mesos.version>0.22.1</mesos.version>
+    <mesos.version>0.27.0</mesos.version>
     <protobuf.version>2.5.0</protobuf.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.2</powermock.version>

--- a/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
@@ -52,14 +52,6 @@ public abstract class Mesos {
       this.role = role;
       this.slaveInfo = slaveInfo;
     }
-
-    public String[] getExternalContainerOptions() {
-      if (this.slaveInfo.getExternalContainerInfo().getOptions().trim().isEmpty()) {
-        return new String[0];
-      } else {
-        return this.slaveInfo.getExternalContainerInfo().getOptions().trim().split(",");
-      }
-    }
   }
 
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -727,15 +727,6 @@ public void setJenkinsURL(String jenkinsURL) {
         for (int i = 0; i < labels.size(); i++) {
           JSONObject label = labels.getJSONObject(i);
           if (label != null) {
-            MesosSlaveInfo.ExternalContainerInfo externalContainerInfo = null;
-            if (label.has("externalContainerInfo")) {
-              JSONObject externalContainerInfoJson = label
-                  .getJSONObject("externalContainerInfo");
-              externalContainerInfo = new MesosSlaveInfo.ExternalContainerInfo(
-                  externalContainerInfoJson.getString("image"),
-                  externalContainerInfoJson.getString("options"));
-            }
-
             MesosSlaveInfo.ContainerInfo containerInfo = null;
             if (label.has("containerInfo")) {
               JSONObject containerInfoJson = label

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -34,7 +34,6 @@ public class MesosSlaveInfo {
   private final boolean defaultSlave;
   // Slave attributes JSON representation.
   private final JSONObject slaveAttributes;
-  private final ExternalContainerInfo externalContainerInfo;
   private final ContainerInfo containerInfo;
   private final List<URI> additionalURIs;
   private final Mode mode;
@@ -194,10 +193,6 @@ public class MesosSlaveInfo {
 
   public String getJnlpArgs() {
     return jnlpArgs;
-  }
-
-  public ExternalContainerInfo getExternalContainerInfo() {
-    return externalContainerInfo;
   }
 
   public boolean isDefaultSlave() {

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -212,16 +212,6 @@
                             </f:entry>
                         </f:optionalBlock>
 
-                        <f:optionalBlock title="${%Use External Containerizer}" name="externalContainerInfo" checked="${slaveInfo.externalContainerInfo != null}">
-                            <f:entry title="${%External Container image}" field="image" description="Docker image requires prefix docker:///">
-                                <f:textbox field="image" value="${slaveInfo.externalContainerInfo.image}" default=""/>
-                            </f:entry>
-
-                            <f:entry title="${%External Container options}" field="options" description="Comma separated list of options to pass to the containerizer">
-                                <f:textbox field="options" value="${slaveInfo.externalContainerInfo.options}" default=""/>
-                            </f:entry>
-                        </f:optionalBlock>
-
                         <f:entry title="${%Additional URIs}" field="additionalURIs">
                             <f:repeatable add="${%Add URI}" var="uri" name="additionalURIs" items="${slaveInfo.additionalURIs}" noAddButton="false" minimum="0">
                                 <fieldset>


### PR DESCRIPTION
We require now mesos 0.27.0 to build the plugin but we retain runtime compatibility with versions older than 0.25.0 by using reflection for the changed API.

External containerizer has been deprecated in Mesos, so support has been removed from the plugin.

@reviewbybees 