### PR TITLE
Wait for slave to come online to avoid provisioning of additional slaves

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
@@ -119,7 +119,7 @@ public class MesosComputerLauncher extends ComputerLauncher {
       try {
         LOGGER.info("Waiting for slave computer connection " + name);
         Thread.sleep(5000);
-      } catch (InterruptedException ignored) {}
+      } catch (InterruptedException ignored) { return; }
     }
     if (computer.isOnline()) {
       LOGGER.info("Slave computer connected " + name);

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
@@ -107,22 +107,22 @@ public class MesosComputerLauncher extends ComputerLauncher {
       // Since we just launched a slave, remove it from pending deletion in case it was marked previously while
       // we were waiting for resources to be available
       computer.getNode().setPendingDelete(false);
-      waitForSlaveConnection(computer);
+      waitForSlaveConnection(computer, logger);
       logger.println("Successfully launched slave" + name);
     }
 
     LOGGER.info("Finished launching slave computer " + name);
   }
 
-  private void waitForSlaveConnection(MesosComputer computer) {
+  private void waitForSlaveConnection(MesosComputer computer, PrintStream logger) {
     while (computer.isOffline() && computer.isConnecting()) {
       try {
-        LOGGER.info("Waiting for slave computer connection " + name);
+        logger.println("Waiting for slave computer connection " + name);
         Thread.sleep(5000);
       } catch (InterruptedException ignored) { return; }
     }
     if (computer.isOnline()) {
-      LOGGER.info("Slave computer connected " + name);
+      logger.println("Slave computer connected " + name);
     } else {
       LOGGER.warning("Slave computer offline " + name);
     }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
@@ -107,10 +107,25 @@ public class MesosComputerLauncher extends ComputerLauncher {
       // Since we just launched a slave, remove it from pending deletion in case it was marked previously while
       // we were waiting for resources to be available
       computer.getNode().setPendingDelete(false);
+      waitForSlaveConnection(computer);
       logger.println("Successfully launched slave" + name);
     }
 
     LOGGER.info("Finished launching slave computer " + name);
+  }
+
+  private void waitForSlaveConnection(MesosComputer computer) {
+    while (computer.isOffline() && computer.isConnecting()) {
+      try {
+        LOGGER.info("Waiting for slave computer connection " + name);
+        Thread.sleep(5000);
+      } catch (InterruptedException ignored) {}
+    }
+    if (computer.isOnline()) {
+      LOGGER.info("Slave computer connected " + name);
+    } else {
+      LOGGER.warning("Slave computer offline " + name);
+    }
   }
 
   /**


### PR DESCRIPTION
If the slave is not connected, Jenkins might try to launch additional slaves which results in over-provisioning slaves and reserving additional resources in the mesos cluster.

@reviewbybees