### PR TITLE
Fix another case of duplicate framework registration

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -939,7 +939,7 @@ public class JenkinsScheduler implements Scheduler {
                 + " | Pending tasks: " + pendingTasks + " | Active tasks: " + activeTasks);
             if (!activeTasks && !activeSlaves && !pendingTasks) {
               LOGGER.info("No active tasks, or slaves or pending slave requests. Stopping the scheduler.");
-              cloud.stopScheduler(false);
+              cloud.stopScheduler();
             }
           } else {
             LOGGER.info("Scheduler already stopped. NOOP.");

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -939,7 +939,7 @@ public class JenkinsScheduler implements Scheduler {
                 + " | Pending tasks: " + pendingTasks + " | Active tasks: " + activeTasks);
             if (!activeTasks && !activeSlaves && !pendingTasks) {
               LOGGER.info("No active tasks, or slaves or pending slave requests. Stopping the scheduler.");
-              cloud.stopScheduler();
+              cloud.stopScheduler(false);
             }
           } else {
             LOGGER.info("Scheduler already stopped. NOOP.");

--- a/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
@@ -76,10 +76,17 @@ public abstract class Mesos {
   abstract public boolean isSchedulerRunning();
 
   /**
+   * Stops the scheduler gracefully.
+   * @return {@code true} if the scheduler is stopped after the call, {@code false} otherwise.
+   */
+  public boolean stopScheduler() {
+    return stopScheduler(false);
+  }
+  /**
    * Stops the scheduler.
    * @param force {@code false} to stop the scheduler gracefully, {@code true} to force stop
    * @return {@code true} if the scheduler is stopped after the call, {@code false} otherwise.
-     */
+   */
   abstract public boolean stopScheduler(boolean force);
   abstract public Scheduler getScheduler();
   /**

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -150,6 +150,7 @@ public class MesosCloud extends Cloud {
       String frameworkName,
       String role,
       String slavesUser,
+      String credentialsId,
       String principal,
       String secret,
       List<MesosSlaveInfo> slaveInfos,
@@ -158,7 +159,7 @@ public class MesosCloud extends Cloud {
       String jenkinsURL,
       String declineOfferDuration) throws NumberFormatException {
     this("MesosCloud", nativeLibraryPath, master, description, frameworkName, role,
-         slavesUser, principal, secret, slaveInfos, checkpoint, onDemandRegistration,
+         slavesUser, credentialsId, principal, secret, slaveInfos, checkpoint, onDemandRegistration,
          jenkinsURL, declineOfferDuration);
   }
 
@@ -175,6 +176,7 @@ public class MesosCloud extends Cloud {
       String frameworkName,
       String role,
       String slavesUser,
+      String credentialsId,
       String principal,
       String secret,
       List<MesosSlaveInfo> slaveInfos,
@@ -190,6 +192,7 @@ public class MesosCloud extends Cloud {
     this.frameworkName = frameworkName;
     this.role = role;
     this.slavesUser = slavesUser;
+    this.credentialsId = credentialsId;
     this.principal = principal;
     this.secret = secret;
     migrateToCredentials();
@@ -218,9 +221,8 @@ public class MesosCloud extends Cloud {
    */
   public MesosCloud(@Nonnull String name, @Nonnull MesosCloud source) {
       this(name, source.nativeLibraryPath, source.master, source.description, source.frameworkName,
-           source.role, source.slavesUser, source.principal, source.secret, source.slaveInfos,
+           source.role, source.slavesUser, source.credentialsId, source.principal, source.secret, source.slaveInfos,
            source.checkpoint, source.onDemandRegistration, source.jenkinsURL, source.declineOfferDuration);
-      this.credentialsId = source.getCredentialsId();
   }
 
   @Override
@@ -341,7 +343,7 @@ public class MesosCloud extends Cloud {
         LOGGER.info("Scheduler was down, restarting the scheduler");
       }
 
-      Mesos.getInstance(this).stopScheduler();
+      Mesos.getInstance(this).stopScheduler(true);
       Mesos.getInstance(this).startScheduler(jenkinsRootURL, this);
     } else {
       Mesos.getInstance(this).updateScheduler(jenkinsRootURL, this);
@@ -517,7 +519,6 @@ public class MesosCloud extends Cloud {
     return credentialsId;
   }
 
-  @DataBoundSetter
   public void setCredentialsId(String credentialsId) {
     this.credentialsId = credentialsId;
   }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosImpl.java
@@ -12,7 +12,6 @@ public class MesosImpl extends Mesos {
   public void startScheduler(String jenkinsMaster, MesosCloud mesosCloud) {
     lock();
     try {
-      stopScheduler();
       scheduler = new JenkinsScheduler(jenkinsMaster, mesosCloud);
       scheduler.init();
     } finally {
@@ -31,17 +30,20 @@ public class MesosImpl extends Mesos {
   }
 
   @Override
-  public void stopScheduler() {
+  public boolean stopScheduler(boolean force) {
     lock();
     try {
       if (scheduler != null) {
-        if (scheduler.reachedMinimumTimeToLive()) {
+        if (force || scheduler.reachedMinimumTimeToLive()) {
           scheduler.stop();
           scheduler = null;
+          return true;
         } else {
           LOGGER.info("Not stopping scheduler because it has been created too recently.");
+          return false;
         }
       }
+      return true;
     } finally {
       unlock();
     }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -44,6 +44,58 @@ public class MesosSlaveInfo {
   private static final Logger LOGGER = Logger.getLogger(MesosSlaveInfo.class
       .getName());
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    MesosSlaveInfo that = (MesosSlaveInfo) o;
+
+    if (Double.compare(that.slaveCpus, slaveCpus) != 0) return false;
+    if (slaveMem != that.slaveMem) return false;
+    if (Double.compare(that.executorCpus, executorCpus) != 0) return false;
+    if (maxExecutors != that.maxExecutors) return false;
+    if (executorMem != that.executorMem) return false;
+    if (idleTerminationMinutes != that.idleTerminationMinutes) return false;
+    if (remoteFSRoot != null ? !remoteFSRoot.equals(that.remoteFSRoot) : that.remoteFSRoot != null) return false;
+    if (jvmArgs != null ? !jvmArgs.equals(that.jvmArgs) : that.jvmArgs != null) return false;
+    if (jnlpArgs != null ? !jnlpArgs.equals(that.jnlpArgs) : that.jnlpArgs != null) return false;
+    if (slaveAttributes != null ? !slaveAttributes.equals(that.slaveAttributes) : that.slaveAttributes != null)
+      return false;
+    if (externalContainerInfo != null ? !externalContainerInfo.equals(that.externalContainerInfo) : that.externalContainerInfo != null)
+      return false;
+    if (containerInfo != null ? !containerInfo.equals(that.containerInfo) : that.containerInfo != null) return false;
+    if (additionalURIs != null ? !additionalURIs.equals(that.additionalURIs) : that.additionalURIs != null)
+      return false;
+    if (mode != that.mode) return false;
+    return labelString != null ? labelString.equals(that.labelString) : that.labelString == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result;
+    long temp;
+    temp = Double.doubleToLongBits(slaveCpus);
+    result = (int) (temp ^ (temp >>> 32));
+    result = 31 * result + slaveMem;
+    temp = Double.doubleToLongBits(executorCpus);
+    result = 31 * result + (int) (temp ^ (temp >>> 32));
+    result = 31 * result + maxExecutors;
+    result = 31 * result + executorMem;
+    result = 31 * result + (remoteFSRoot != null ? remoteFSRoot.hashCode() : 0);
+    result = 31 * result + idleTerminationMinutes;
+    result = 31 * result + (jvmArgs != null ? jvmArgs.hashCode() : 0);
+    result = 31 * result + (jnlpArgs != null ? jnlpArgs.hashCode() : 0);
+    result = 31 * result + (slaveAttributes != null ? slaveAttributes.hashCode() : 0);
+    result = 31 * result + (externalContainerInfo != null ? externalContainerInfo.hashCode() : 0);
+    result = 31 * result + (containerInfo != null ? containerInfo.hashCode() : 0);
+    result = 31 * result + (additionalURIs != null ? additionalURIs.hashCode() : 0);
+    result = 31 * result + (mode != null ? mode.hashCode() : 0);
+    result = 31 * result + (labelString != null ? labelString.hashCode() : 0);
+    return result;
+  }
+
   @DataBoundConstructor
   public MesosSlaveInfo(
       String labelString,
@@ -196,6 +248,25 @@ public class MesosSlaveInfo {
     public String getImage() {
       return image;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      ExternalContainerInfo that = (ExternalContainerInfo) o;
+
+      if (image != null ? !image.equals(that.image) : that.image != null) return false;
+      return options != null ? options.equals(that.options) : that.options == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+      int result = image != null ? image.hashCode() : 0;
+      result = 31 * result + (options != null ? options.hashCode() : 0);
+      return result;
+    }
   }
 
   public static class ContainerInfo {
@@ -291,6 +362,43 @@ public class MesosSlaveInfo {
     public boolean getUseCustomDockerCommandShell() {  return useCustomDockerCommandShell; }
 
     public String getCustomDockerCommandShell() {  return customDockerCommandShell; }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      ContainerInfo that = (ContainerInfo) o;
+
+      if (useCustomDockerCommandShell != that.useCustomDockerCommandShell) return false;
+      if (type != null ? !type.equals(that.type) : that.type != null) return false;
+      if (dockerImage != null ? !dockerImage.equals(that.dockerImage) : that.dockerImage != null) return false;
+      if (volumes != null ? !volumes.equals(that.volumes) : that.volumes != null) return false;
+      if (parameters != null ? !parameters.equals(that.parameters) : that.parameters != null) return false;
+      if (networking != null ? !networking.equals(that.networking) : that.networking != null) return false;
+      if (portMappings != null ? !portMappings.equals(that.portMappings) : that.portMappings != null) return false;
+      if (customDockerCommandShell != null ? !customDockerCommandShell.equals(that.customDockerCommandShell) : that.customDockerCommandShell != null)
+        return false;
+      if (dockerPrivilegedMode != null ? !dockerPrivilegedMode.equals(that.dockerPrivilegedMode) : that.dockerPrivilegedMode != null)
+        return false;
+      return dockerForcePullImage != null ? dockerForcePullImage.equals(that.dockerForcePullImage) : that.dockerForcePullImage == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+      int result = type != null ? type.hashCode() : 0;
+      result = 31 * result + (dockerImage != null ? dockerImage.hashCode() : 0);
+      result = 31 * result + (volumes != null ? volumes.hashCode() : 0);
+      result = 31 * result + (parameters != null ? parameters.hashCode() : 0);
+      result = 31 * result + (networking != null ? networking.hashCode() : 0);
+      result = 31 * result + (portMappings != null ? portMappings.hashCode() : 0);
+      result = 31 * result + (useCustomDockerCommandShell ? 1 : 0);
+      result = 31 * result + (customDockerCommandShell != null ? customDockerCommandShell.hashCode() : 0);
+      result = 31 * result + (dockerPrivilegedMode != null ? dockerPrivilegedMode.hashCode() : 0);
+      result = 31 * result + (dockerForcePullImage != null ? dockerForcePullImage.hashCode() : 0);
+      return result;
+    }
   }
 
   public static class Parameter {


### PR DESCRIPTION
Added a Garbage Collector to stop the scheduler and remove the mesos framework in case the cloud gets removed.

Doing so, I found out that there was a problem related to credentialsId and usage of @DataBoundSetter : when the scheduler is restarted after constructor call (onDemandRegistration=false), credentialsId value is not yet set and this can cause a duplicate framework registration. So the field initialization has been moved to constructor.

Last, added equals/hashCode implementations to MesosSlaveInfo and embedded classes, as these are necessary to compare MesosCloud instances, and these are used in Mesos#getInstance to prevent building duplicate MesosImpl instances.

@reviewbybees 