### PR TITLE
jenkins slave memory fix

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -776,7 +776,7 @@ public class JenkinsScheduler implements Scheduler {
 
         CommandInfo.Builder commandBuilder = CommandInfo.newBuilder();
         String jenkinsCommand2Run = generateJenkinsCommand2Run(
-            request.request.mem,
+            request.request.slaveInfo.getSlaveMem(),
             request.request.slaveInfo.getJvmArgs(),
             request.request.slaveInfo.getJnlpArgs(),
             request.request.slave.name);


### PR DESCRIPTION
Jenkins-slave  can consume all of allocated memory via -Xmx switch. Bugfix:. Only slave memory amount should be assigned.