### PR TITLE
Add a minimum number of executors per slave #232

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -389,6 +389,7 @@ public class MesosCloud extends Cloud {
     if (slaveInfo == null) {
       return list;
     }
+    int minExecutors = slaveInfo.getMinExecutors();
     int maxExecutors = slaveInfo.getMaxExecutors();
 
     try {
@@ -405,7 +406,7 @@ public class MesosCloud extends Cloud {
             JenkinsScheduler.SUPERVISOR_LOCK.unlock();
           }
         }
-        final int numExecutors = Math.min(excessWorkload, maxExecutors);
+        final int numExecutors = Math.max(minExecutors, Math.min(excessWorkload, maxExecutors));
         excessWorkload -= numExecutors;
         LOGGER.info("Provisioning Jenkins Slave on Mesos with " + numExecutors +
                     " executors. Remaining excess workload: " + excessWorkload + " executors)");

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -44,6 +44,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
   private final double slaveCpus;
   private final int slaveMem; // MB.
   private final double executorCpus;
+  private final int minExecutors;
   private final int maxExecutors;
   private final int executorMem; // MB.
   private final String remoteFSRoot;
@@ -74,6 +75,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
     if (Double.compare(that.slaveCpus, slaveCpus) != 0) return false;
     if (slaveMem != that.slaveMem) return false;
     if (Double.compare(that.executorCpus, executorCpus) != 0) return false;
+    if (minExecutors != that.minExecutors) return false;
     if (maxExecutors != that.maxExecutors) return false;
     if (executorMem != that.executorMem) return false;
     if (idleTerminationMinutes != that.idleTerminationMinutes) return false;
@@ -100,6 +102,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
     result = 31 * result + slaveMem;
     temp = Double.doubleToLongBits(executorCpus);
     result = 31 * result + (int) (temp ^ (temp >>> 32));
+    result = 31 * result + minExecutors;
     result = 31 * result + maxExecutors;
     result = 31 * result + executorMem;
     result = 31 * result + (remoteFSRoot != null ? remoteFSRoot.hashCode() : 0);
@@ -121,6 +124,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
       Mode mode,
       String slaveCpus,
       String slaveMem,
+      String minExecutors,
       String maxExecutors,
       String executorCpus,
       String executorMem,
@@ -151,6 +155,10 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
     this.containerInfo = containerInfo;
     this.additionalURIs = additionalURIs;
     this.nodeProperties.replaceBy(nodeProperties == null ? new ArrayList<NodeProperty<?>>() : nodeProperties);
+
+    // Ensure minExecutors is at least equal to 1 and prevent case where minExecutors > maxExecutors.
+    int minExecutorsVal = Integer.parseInt(minExecutors);
+    this.minExecutors = minExecutorsVal < 1 || minExecutorsVal > this.maxExecutors ? 1 : minExecutorsVal;
 
     // Parse the attributes provided from the cloud config
     JSONObject jsonObject = null;
@@ -184,6 +192,10 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
 
   public int getSlaveMem() {
     return slaveMem;
+  }
+
+  public int getMinExecutors() {
+    return minExecutors;
   }
 
   public int getMaxExecutors() {

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/config.jelly
@@ -22,6 +22,10 @@
         <f:number clazz="required positive-number" default="512"/>
     </f:entry>
 
+    <f:entry title="${%Minimum number of Executors per Slave}" field="minExecutors">
+        <f:number clazz="required number" default="1"/>
+    </f:entry>
+
     <f:entry title="${%Maximum number of Executors per Slave}" field="maxExecutors">
         <f:number clazz="required number" default="2"/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/help-minExecutors.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/help-minExecutors.html
@@ -1,0 +1,3 @@
+<div>
+    This is the minimum number of executors the slave will have once connected to Jenkins.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -283,6 +283,7 @@ public class JenkinsSchedulerTest {
                 Node.Mode.NORMAL,
                 "0.2",              // slaveCpus,
                 "512",              // slaveMem,
+                "1",                // minExecutors,
                 "2",                // maxExecutors,
                 "0.2",              // executorCpus,
                 "512",              // executorMem,


### PR DESCRIPTION
Current behavior won't change (default value set to 1) and the update of the workload has been modified to take in account this parameter.