### PR TITLE
Simple "Maintenance Mode" Implementation (not using Maintenance Primitives)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -22,37 +22,12 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.util.Secret;
-
-import java.lang.Math;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-
 import org.apache.commons.collections4.OrderedMapIterator;
 import org.apache.commons.collections4.map.LRUMap;
 import org.apache.commons.lang.StringUtils;
 import org.apache.mesos.MesosSchedulerDriver;
-import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Attribute;
 import org.apache.mesos.Protos.CommandInfo;
 import org.apache.mesos.Protos.ContainerInfo;
@@ -80,6 +55,26 @@ import org.apache.mesos.Protos.Volume;
 import org.apache.mesos.Protos.Volume.Mode;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class JenkinsScheduler implements Scheduler {
   private static final String SLAVE_JAR_URI_SUFFIX = "jnlpJars/slave.jar";
@@ -407,6 +402,14 @@ public class JenkinsScheduler implements Scheduler {
     double cpus = -1;
     double mem = -1;
     List<Range> ports = null;
+
+    String hostname = offer.getHostname();
+    for (String declinedHost : mesosCloud.getDeclineHostsList()) {
+      if (hostname.matches(declinedHost)) {
+        LOGGER.info("Offer from " + hostname + " rejected because it matches '" + declinedHost + "'.");
+        return false;
+      }
+    }
 
     for (Resource resource : offer.getResourcesList()) {
       String resourceRole = resource.getRole();

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -2,21 +2,11 @@ package org.jenkinsci.plugins.mesos;
 
 import hudson.Extension;
 import hudson.Util;
-
-import hudson.model.*;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.annotation.CheckForNull;
-
+import hudson.model.Label;
+import hudson.model.Node;
 import hudson.model.Node.Mode;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
@@ -26,11 +16,20 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+
+import javax.annotation.CheckForNull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
   @Extension
@@ -363,7 +362,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
 
   /**
    * Check if the label in the slave matches the provided label, either both are null or are the same.
-   * 
+   *
    * @param label
    * @return Whether the slave label matches.
    */
@@ -376,7 +375,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
       return true;
     }
 
-    if (!containerInfo.getDockerImageCustomizable()) {
+    if (containerInfo == null || !containerInfo.getDockerImageCustomizable()) {
       return false;
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -28,6 +28,10 @@
         <c:select/>
     </f:entry>
 
+    <f:entry title="${%Decline Hosts }" description="${%Regex-match Hostnames to decline offers}" field="declineHosts">
+      <f:textbox/>
+    </f:entry>
+
     <f:entry title="${%Jenkins URL }" field="jenkinsURL">
       <f:textbox/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-declineHosts.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-declineHosts.html
@@ -1,0 +1,5 @@
+<div>
+    Comma-separated list of regular expressions to decline an offer based on hostname.<br />
+    This is useful for excluding specific hosts that you are trying to take down for maintenance.<br />
+    This should likely be removed once Maintenance Primitives are supported.<br />
+</div>


### PR DESCRIPTION
#216

This is a "better than nothing" change until the Maintenance Primitives can be used, but that's going to be a while.

Added a decline hosts setting to pass in a CSV of regex patterns to match hosts that you don't want jobs scheduled on. Primary use case is maintenance mode. 

Default value, blank, has no change in behavior.

Also made a change in MesosSlaveInfo that assumes you're using a docker container for your slave.

```
if (!containerInfo.getDockerImageCustomizable()) {
```

became
    if (containerInfo == null || !containerInfo.getDockerImageCustomizable()) {
