### PR TITLE
Fix mesos cloud config bug

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -155,7 +155,7 @@ public class JenkinsScheduler implements Scheduler {
             // Set a failover timeout so that tasks are not immediately killed
             // when the scheduler disconnects.
             .setFailoverTimeout(mesosCloud.getFailoverTimeoutDouble());
-    		if (mesosCloud.getFrameworkID() != null) 
+    		if (mesosCloud.getFrameworkID() != null || !mesosCloud.getFrameworkID().isEmpty())
     		{
                 frameworkInfo.setId(FrameworkID.newBuilder()
                 		.setValue(mesosCloud.getFrameworkID()).build());
@@ -164,11 +164,9 @@ public class JenkinsScheduler implements Scheduler {
             + "\n" + "Framework Name: " + frameworkInfo.getName()
             + "\n" + "Principal: " + principal
             + "\n" + "Checkpointing: " + frameworkInfo.getCheckpoint()
-            //REMOVE THIS
             + "\n" + "Failover Timeout: " + frameworkInfo.getFailoverTimeout()
             + "\n" + "Framework ID: " + frameworkInfo.getId()
     );
-
     if (StringUtils.isNotBlank(secret)) {
 
       Credential credential = Credential.newBuilder()
@@ -187,7 +185,6 @@ public class JenkinsScheduler implements Scheduler {
       public void run() {
         try {
           Status runStatus = driver.run();
-          LOGGER.info(runStatus.toString());
           if (runStatus != Status.DRIVER_STOPPED) {
             LOGGER.severe("The Mesos driver was aborted! Status code: " + runStatus.getNumber());
           } else {
@@ -213,6 +210,7 @@ public class JenkinsScheduler implements Scheduler {
       SUPERVISOR_LOCK.lock();
       if (driver != null) {
         LOGGER.info("Stopping Mesos driver.");
+        //It might not be necessary/beneficial to have this set to TRUE -unclear
         driver.stop(true);
       } else {
         LOGGER.warning("Unable to stop Mesos driver:  driver is null.");

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2013 Twitter, Inc. and other contributors.
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -151,6 +152,8 @@ public class JenkinsScheduler implements Scheduler {
             .setPrincipal(principal)
             .setCheckpoint(mesosCloud.isCheckpoint())
             .setWebuiUrl(webUrl != null ? webUrl : "")
+            // Set a failover timeout so that tasks are not immediately killed
+            // when the scheduler disconnects.
             .setFailoverTimeout(mesosCloud.getFailoverTimeoutDouble());
     		if (mesosCloud.getFrameworkID() != null) 
     		{
@@ -184,6 +187,7 @@ public class JenkinsScheduler implements Scheduler {
       public void run() {
         try {
           Status runStatus = driver.run();
+          LOGGER.info(runStatus.toString());
           if (runStatus != Status.DRIVER_STOPPED) {
             LOGGER.severe("The Mesos driver was aborted! Status code: " + runStatus.getNumber());
           } else {
@@ -310,6 +314,9 @@ public class JenkinsScheduler implements Scheduler {
   @Override
   public void registered(SchedulerDriver driver, FrameworkID frameworkId, MasterInfo masterInfo) {
     LOGGER.info("Framework registered! ID = " + frameworkId.getValue());
+    // Set the frameworkId to the auto-id provided by mesos
+    // so the scheduler can reregister later. Does not persist
+    // across Jenkins restarts
     mesosCloud.setFrameworkID(frameworkId.getValue().toString());
   }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -712,14 +712,21 @@ public void setJenkinsURL(String jenkinsURL) {
   }
   
   public String getFailoverTimeout() {
-	  if(failoverTimeout.isEmpty())
+	  if(failoverTimeout.isEmpty() || failoverTimeout == null)
 		  failoverTimeout = DEFAULT_FAILOVER_TIMEOUT;
 		return failoverTimeout;
 	}
 
   public double getFailoverTimeoutDouble() {
-		return Double.parseDouble(getFailoverTimeout());
-	}
+    try {
+      return Double.parseDouble(getFailoverTimeout());
+      } catch (NumberFormatException e) {
+        LOGGER.warning("Unable to parse failoverTimeout: " + failoverTimeout
+               + ". Using default " + DEFAULT_FAILOVER_TIMEOUT + ".");
+        this.failoverTimeout = DEFAULT_FAILOVER_TIMEOUT;
+      }
+        return Double.parseDouble(getFailoverTimeout());
+    }
   
   public void setFailoverTimeout(String failoverTimeout) {
 		this.failoverTimeout = failoverTimeout;

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -66,6 +66,7 @@ import java.util.logging.Logger;
 
 public class MesosCloud extends Cloud {
   private static final String DEFAULT_DECLINE_OFFER_DURATION = "600000"; // 10 mins.
+  private static final String DEFAULT_FAILOVER_TIMEOUT = "0.0"; 
   private String nativeLibraryPath;
   private String master;
   private String description;
@@ -73,6 +74,7 @@ public class MesosCloud extends Cloud {
   private String role;
   private String slavesUser;
   private String credentialsId;
+  private String frameworkID;
   /**
    * @deprecated Create credentials then use credentialsId instead.
    */
@@ -87,6 +89,7 @@ public class MesosCloud extends Cloud {
   private boolean onDemandRegistration; // If set true, this framework disconnects when there are no builds in the queue and re-registers when there are.
   private String jenkinsURL;
   private String declineOfferDuration;
+  private String failoverTimeout;
 
   // Find the default values for these variables in
   // src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly.
@@ -159,10 +162,12 @@ public class MesosCloud extends Cloud {
       boolean checkpoint,
       boolean onDemandRegistration,
       String jenkinsURL,
-      String declineOfferDuration) throws NumberFormatException {
+      String declineOfferDuration,
+      String failoverTimeout,
+      String frameworkID) throws NumberFormatException {
     this("MesosCloud", nativeLibraryPath, master, description, frameworkName, role,
          slavesUser, credentialsId, principal, secret, slaveInfos, checkpoint, onDemandRegistration,
-         jenkinsURL, declineOfferDuration);
+         jenkinsURL, declineOfferDuration, failoverTimeout, frameworkID);
   }
 
   /**
@@ -185,7 +190,9 @@ public class MesosCloud extends Cloud {
       boolean checkpoint,
       boolean onDemandRegistration,
       String jenkinsURL,
-      String declineOfferDuration) throws NumberFormatException {
+      String declineOfferDuration,
+      String failoverTimeout,
+      String frameworkID) throws NumberFormatException {
     super(cloudName);
 
     this.nativeLibraryPath = nativeLibraryPath;
@@ -203,6 +210,8 @@ public class MesosCloud extends Cloud {
     this.onDemandRegistration = onDemandRegistration;
     this.setJenkinsURL(jenkinsURL);
     this.setDeclineOfferDuration(declineOfferDuration);
+    this.setFailoverTimeout(failoverTimeout);
+    this.setFrameworkID(frameworkID);
     if(!onDemandRegistration) {
 	    JenkinsScheduler.SUPERVISOR_LOCK.lock();
 	    try {
@@ -224,7 +233,8 @@ public class MesosCloud extends Cloud {
   public MesosCloud(@Nonnull String name, @Nonnull MesosCloud source) {
       this(name, source.nativeLibraryPath, source.master, source.description, source.frameworkName,
            source.role, source.slavesUser, source.credentialsId, source.principal, source.secret, source.slaveInfos,
-           source.checkpoint, source.onDemandRegistration, source.jenkinsURL, source.declineOfferDuration);
+           source.checkpoint, source.onDemandRegistration, source.jenkinsURL, source.declineOfferDuration, 
+           source.failoverTimeout, source.frameworkID);
   }
 
   @Override
@@ -253,6 +263,16 @@ public class MesosCloud extends Cloud {
         return false;
     } else if (!description.equals(other.description))
       return false;
+    if (failoverTimeout == null) {
+        if (other.failoverTimeout != null)
+          return false;
+      } else if (!failoverTimeout.equals(other.failoverTimeout))
+        return false;
+    if (frameworkID == null) {
+        if (other.frameworkID != null)
+          return false;
+      } else if (!frameworkID.equals(other.frameworkID))
+        return false;
     if (frameworkName == null) {
       if (other.frameworkName != null)
         return false;
@@ -302,6 +322,8 @@ public class MesosCloud extends Cloud {
     result =
         prime * result + ((declineOfferDuration == null) ? 0 : declineOfferDuration.hashCode());
     result = prime * result + ((description == null) ? 0 : description.hashCode());
+    result = prime * result + ((failoverTimeout == null) ? 0 : failoverTimeout.hashCode());
+    result = prime * result + ((frameworkID == null) ? 0 : frameworkID.hashCode());
     result = prime * result + ((frameworkName == null) ? 0 : frameworkName.hashCode());
     result = prime * result + ((jenkinsURL == null) ? 0 : jenkinsURL.hashCode());
     result = prime * result + ((master == null) ? 0 : master.hashCode());
@@ -688,6 +710,28 @@ public void setJenkinsURL(String jenkinsURL) {
       this.declineOfferDuration = DEFAULT_DECLINE_OFFER_DURATION;
     }
   }
+  
+  public String getFailoverTimeout() {
+	  if(failoverTimeout.isEmpty())
+		  failoverTimeout = DEFAULT_FAILOVER_TIMEOUT;
+		return failoverTimeout;
+	}
+
+  public double getFailoverTimeoutDouble() {
+		return Double.parseDouble(getFailoverTimeout());
+	}
+  
+  public void setFailoverTimeout(String failoverTimeout) {
+		this.failoverTimeout = failoverTimeout;
+	}
+
+  public String getFrameworkID() {
+	  return frameworkID;
+	}
+
+  public void setFrameworkID(String frameworkID) {
+	  this.frameworkID = frameworkID;
+	}
 
 @Extension
   public static class DescriptorImpl extends Descriptor<Cloud> {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -719,7 +719,7 @@ public void setJenkinsURL(String jenkinsURL) {
 
   public double getFailoverTimeoutDouble() {
     try {
-      return Double.parseDouble(getFailoverTimeout());
+        return Double.parseDouble(getFailoverTimeout());
       } catch (NumberFormatException e) {
         LOGGER.warning("Unable to parse failoverTimeout: " + failoverTimeout
                + ". Using default " + DEFAULT_FAILOVER_TIMEOUT + ".");

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -32,6 +32,10 @@
       <f:textbox/>
     </f:entry>
 
+    <f:entry title="${%Failover Timeout }" field="failoverTimeout">
+      <f:number class ="required positive-number" default="0.0" />
+    </f:entry>
+
     <f:advanced>
         <f:entry title="${%Checkpointing}" description="${%Enable Mesos framework checkpointing?}" field="checkpoint">
             <f:radio name="checkpoint" value="true" checked="${instance.checkpoint == true}" id="checkpoint.true"/>
@@ -51,6 +55,10 @@
           <f:number clazz="required positive-number" min="1000" steps="1000" default="600000"/>
         </f:entry>
 
+		<f:entry title="${%FrameworkID}">
+			<f:textbox readonly="readonly" field="frameworkID"/>
+		</f:entry>
+        
         <f:entry>
             <f:repeatableProperty field="slaveInfos" minimum="1">
                 <f:entry>
@@ -60,6 +68,7 @@
                 </f:entry>
             </f:repeatableProperty>
         </f:entry>
+        
     </f:advanced>
 
     <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="master,nativeLibraryPath"/>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-failoverTimeout.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-failoverTimeout.html
@@ -1,0 +1,3 @@
+<div>
+    The amount of time (in seconds) that the master will wait for the scheduler to failover before it tears down the framework by killing all its tasks/executors.
+</div>


### PR DESCRIPTION
Saving a new CloudConfig causes all running tasks to terminate because the Jenkins scheduler is (incorrectly) being restarted upon every config change. These changes address this problem and allow the Jenkins scheduler to stay running when config changes are made to the MesosCloud.

I have left the implementation of failoverTimeout in my code, but it doesn't seem to have any use at the moment, since Jenkins tears down all jobs upon restart.
