### PR TITLE
Fix: Modifying MesosCloud Configuration Kills Running Jobs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -33,7 +33,7 @@ public class MesosSlave extends Slave {
 
   private static final long serialVersionUID = 1L;
 
-  private final String cloudId;
+  private final String cloudName;
   private transient MesosCloud cloud;
   private final MesosSlaveInfo slaveInfo;
   private final int idleTerminationMinutes;
@@ -55,7 +55,7 @@ public class MesosSlave extends Slave {
           new MesosRetentionStrategy(slaveInfo.getIdleTerminationMinutes()),
           slaveInfo.getNodeProperties());
     this.cloud = cloud;
-    this.cloudId = cloud.getDisplayName();
+    this.cloudName = cloud.getDisplayName();
     this.slaveInfo = slaveInfo;
     this.idleTerminationMinutes = slaveInfo.getIdleTerminationMinutes();
     this.cpus = slaveInfo.getSlaveCpus() + (numExecutors * slaveInfo.getExecutorCpus());
@@ -65,7 +65,7 @@ public class MesosSlave extends Slave {
 
   public MesosCloud getCloud() {
     if (cloud == null) {
-      cloud = (MesosCloud) getJenkins().getCloud(cloudId);
+      cloud = (MesosCloud) getJenkins().getCloud(cloudName);
     }
     return cloud;
   }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -368,6 +368,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
    * @return Whether the slave label matches.
    */
   public boolean matchesLabel(@CheckForNull Label label) {
+
     if (label == null || getLabelString() == null) {
       return label == null && getLabelString() == null;
     }
@@ -376,7 +377,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
       return true;
     }
 
-    if (!containerInfo.getDockerImageCustomizable()) {
+    if (containerInfo == null || !containerInfo.getDockerImageCustomizable()) {
       return false;
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -29,7 +29,11 @@
     </f:entry>
 
     <f:entry title="${%Jenkins URL }" field="jenkinsURL">
-      <f:textbox/>
+        <f:textbox/>
+    </f:entry>
+
+    <f:entry title="${%Cloud ID}" field ="cloudID">
+ 	 <f:textbox readonly="readonly" />
     </f:entry>
 
     <f:advanced>
@@ -50,7 +54,7 @@
         <f:entry title="${%Decline offer duration}" field="declineOfferDuration" description="${%Decline offers for specified amount of time in case no slave is queued. The plugin asks for new offers in case a new slave needs to be started. In milliseconds.}">
           <f:number clazz="required positive-number" min="1000" steps="1000" default="600000"/>
         </f:entry>
-
+        
         <f:entry>
             <f:repeatableProperty field="slaveInfos" minimum="1">
                 <f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-cloudID.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/help-cloudID.html
@@ -1,0 +1,3 @@
+<div>
+    This is a unique ID automatically assigned and associated with this MesosCloud.
+</div>


### PR DESCRIPTION
Saving a new MesosCloud config causes all running tasks to terminate because the Jenkins scheduler is being needlessly restarted upon every config change. These changes address this problem and allow the Jenkins scheduler to stay running when config changes are made to the MesosCloud.

The root cause of this issue was the GarbageCollector in Mesos.Java incorrectly removing modified (not removed) clouds - this is a consequence of using mutable keys in a HashMap. As a fix, I have implemented a cloudID that serves as a unique identifier for each MesosCloud. This allows for "modified" clouds (i.e. same cloud with a changed description or slaveInfo) to be recognized and not accidentally removed by the GarbageCollector.

I also fixed a NPE occuring in the matchesLabel method.