### PR TITLE
Passing ${app.rootUrlFromRequest} and ${rootUrl} as -url arguments

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosComputer/mesos-slave-agent.jnlp.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosComputer/mesos-slave-agent.jnlp.jelly
@@ -46,6 +46,8 @@
 
         <argument>-url</argument>
         <argument>${app.rootUrlFromRequest}</argument>
+        <argument>-url</argument>
+        <argument>${rootURL}</argument>
       </application-desc>
     </jnlp>
 </j:jelly>


### PR DESCRIPTION
#258 Passing ${app.rootUrlFromRequest} and ${rootUrl} as -url arguments make it more broadly compatible.

I ordered them http, then https, and it works in my environment, where it didn't before.
