### PR TITLE
Update Jenkins dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,6 @@
   </pluginRepositories>
 
   <properties>
-    <jenkins.version>1.599</jenkins.version>
-    <jenkins-test-harness.version>1.599</jenkins-test-harness.version>
     <findbugs.failOnError>false</findbugs.failOnError>
     <mesos.version>1.0.0</mesos.version>
     <protobuf.version>2.6.1</protobuf.version>
@@ -99,7 +97,7 @@
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>credentials</artifactId>
-          <version>1.22</version>
+          <version>1.28</version>
       </dependency>
       <dependency>
           <groupId>org.apache.mesos</groupId>
@@ -153,7 +151,7 @@
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>metrics</artifactId>
-          <version>3.1.2.6</version>
+          <version>3.1.2.9</version>
           <optional>true</optional>
       </dependency>
   </dependencies>
@@ -174,7 +172,7 @@
           <plugin>
               <groupId>org.jenkins-ci.tools</groupId>
               <artifactId>maven-hpi-plugin</artifactId>
-              <version>1.117</version>
+              <version>1.121</version>
               <configuration>
                   <systemProperties>
                       <hudson.slaves.NodeProvisioner.initialDelay>0</hudson.slaves.NodeProvisioner.initialDelay>


### PR DESCRIPTION
When I run tests I encourage following error:
```
Tests in error:
InjectedTest.initializationError(InjectedTest)
  Run 1: InjectedTest.suite:15 » NoClassDefFound org/mortbay/component/LifeCycle
  Run 2: InjectedTest.suite:15 » NoClassDefFound org/mortbay/component/LifeCycle
  Run 3: InjectedTest.suite:15 » NoClassDefFound org/mortbay/component/LifeCycle
  Run 4: InjectedTest.suite:15 » NoClassDefFound org/mortbay/component/LifeCycle
  Run 5: InjectedTest.suite:15 » NoClassDefFound org/mortbay/component/LifeCycle
```
Updating Jenkins dependecies fixed issue.