### PR TITLE
Ensure task is launched with appropriate roles on ports from offer.

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -46,6 +46,7 @@ public class JenkinsSchedulerTest {
     private static String TEST_JENKINS_SLAVE_ARG   = "-Xms16m -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true";
     private static String TEST_JENKINS_JNLP_ARG    = "";
     private static String TEST_JENKINS_SLAVE_NAME  = "testSlave1";
+    private static String TEST_MESOS_ROLE_NAME     = "test_role";
 
 
     @Before
@@ -61,6 +62,13 @@ public class JenkinsSchedulerTest {
 
         jenkinsScheduler = new JenkinsScheduler("jenkinsMaster", mesosCloud);
 
+    }
+
+    @Test
+    public void testFindRoleForPorts() {
+        Protos.Offer offer = createOfferWithRoleForPorts();
+        String role = jenkinsScheduler.findRoleForPorts(offer);
+        assertEquals(TEST_MESOS_ROLE_NAME, role);
     }
 
     @Test
@@ -355,6 +363,32 @@ public class JenkinsSchedulerTest {
         Protos.Resource resource = Protos.Resource.newBuilder()
                 .setName("ports")
                 .setRanges(ranges)
+                .setType(Protos.Value.Type.RANGES)
+                .build();
+
+        return Protos.Offer.newBuilder()
+                .addResources(resource)
+                .setId(Protos.OfferID.newBuilder().setValue("value").build())
+                .setFrameworkId(Protos.FrameworkID.newBuilder().setValue("value").build())
+                .setSlaveId(Protos.SlaveID.newBuilder().setValue("value").build())
+                .setHostname("hostname")
+                .build();
+    }
+
+    private Protos.Offer createOfferWithRoleForPorts() {
+        Protos.Value.Range range = Protos.Value.Range.newBuilder()
+                .setBegin(31000)
+                .setEnd(32000)
+                .build();
+
+        Protos.Value.Ranges ranges = Protos.Value.Ranges.newBuilder()
+                .addRange(range)
+                .build();
+
+        Protos.Resource resource = Protos.Resource.newBuilder()
+                .setName("ports")
+                .setRanges(ranges)
+                .setRole(TEST_MESOS_ROLE_NAME)
                 .setType(Protos.Value.Type.RANGES)
                 .build();
 


### PR DESCRIPTION
If a Mesos scheduler is configured with a role, the scheduler receives offers for resources under that defined role (or the default role).

Currently, the code that builds tasks for execution doesn't include any role attached in the offer for assigned port resources.

This PR ensures that the role for port resources on the offer is used, just like it is for cpu and mem.

This problem was manifesting itself with errors in both the Jenkins and mesos-master logs and a number of failed Jenkins slaves would appear in the Jenkins UI, e.g.:

```
Sending status update TASK_ERROR for task mesos-jenkins-506c01240453427bb20f1d3dff26b718-mesos-ultra-e2e of framework 7ef79e0d-1cc1-4880-ad98-7fb0329fa816-0003 'Total resources cpus(jenkins_sg):1.1; mem(jenkins_sg):6899.2; ports(*):[31000-31000] required by task and its executor is more than available cpus(jenkins_sg):29.4; mem(jenkins_sg):118622; disk(jenkins_sg):297124; ports(jenkins_sg):[31000-32000]'
```