### PR TITLE
Add option to specify disk resource.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/Mesos.java
@@ -43,16 +43,18 @@ public abstract class Mesos {
     JenkinsSlave slave;
     final double cpus;
     final int mem;
+    final double diskNeeded;
     final String role;
     final MesosSlaveInfo slaveInfo;
 
     public SlaveRequest(JenkinsSlave slave, double cpus, int mem, String role,
-        MesosSlaveInfo slaveInfo) {
+        MesosSlaveInfo slaveInfo, double diskNeeded) {
       this.slave = slave;
       this.cpus = cpus;
       this.mem = mem;
       this.role = role;
       this.slaveInfo = slaveInfo;
+      this.diskNeeded = diskNeeded;
     }
   }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -784,6 +784,27 @@ public void setJenkinsURL(String jenkinsURL) {
       return doCheckCpus(value);
     }
 
+    public FormValidation doCheckDiskNeeded(@QueryParameter String value) {
+      boolean isValid = true;
+      String errorMessage = "Invalid disk space entered. It should be a positive decimal.";
+
+      if (StringUtils.isBlank(value)){
+        isValid = false;
+      }
+      else {
+        try {
+          if (Double.parseDouble(value) < 0)
+          {
+            isValid = false;
+          }
+        } catch (NumberFormatException e) {
+          isValid = false;
+        }
+      }
+      return isValid ? FormValidation.ok() : FormValidation.error(errorMessage);
+    }
+
+
     private FormValidation doCheckCpus(@QueryParameter String value) {
       boolean valid = true;
       String errorMessage = "Invalid CPUs value, it should be a positive decimal.";

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
@@ -15,7 +15,6 @@
 package org.jenkinsci.plugins.mesos;
 
 import hudson.model.TaskListener;
-import hudson.slaves.ComputerLauncher;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
 
@@ -79,10 +78,11 @@ public class MesosComputerLauncher extends JNLPLauncher {
     // Create the request.
     double cpus = node.getCpus();
     int mem = node.getMem();
+    double diskNeeded = node.getDiskNeeded();
     String role = cloud.getRole();
 
     Mesos.SlaveRequest request = new Mesos.SlaveRequest(new JenkinsSlave(name),
-        cpus, mem, role, node.getSlaveInfo());
+            cpus, mem, role, node.getSlaveInfo(), diskNeeded);
 
     // Launch the jenkins slave.
     final CountDownLatch latch = new CountDownLatch(1);

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlave.java
@@ -39,6 +39,9 @@ public class MesosSlave extends Slave {
   private final int idleTerminationMinutes;
   private final double cpus;
   private final int mem;
+  private final double diskNeeded;
+
+
   private boolean pendingDelete;
 
   private static final Logger LOGGER = Logger.getLogger(MesosSlave.class
@@ -60,6 +63,7 @@ public class MesosSlave extends Slave {
     this.idleTerminationMinutes = slaveInfo.getIdleTerminationMinutes();
     this.cpus = slaveInfo.getSlaveCpus() + (numExecutors * slaveInfo.getExecutorCpus());
     this.mem = slaveInfo.getSlaveMem() + (numExecutors * slaveInfo.getExecutorMem());
+    this.diskNeeded = slaveInfo.getdiskNeeded();
     LOGGER.fine("Constructing Mesos slave " + name + " from cloud " + cloud.getDescription());
   }
 
@@ -84,6 +88,11 @@ public class MesosSlave extends Slave {
 
   public int getMem() {
     return mem;
+  }
+
+
+  public double getDiskNeeded() {
+    return diskNeeded;
   }
 
   public MesosSlaveInfo getSlaveInfo() {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -79,6 +79,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
   private static final String CUSTOM_IMAGE_SEPARATOR = ":";
   private static final Pattern CUSTOM_IMAGE_FROM_LABEL_PATTERN = Pattern.compile(CUSTOM_IMAGE_SEPARATOR + "([\\w\\.\\-/:]+[\\w])");
   private final double slaveCpus;
+  private final double diskNeeded; //MB
   private final int slaveMem; // MB.
   private final double executorCpus;
   private /*almost final*/ int minExecutors;
@@ -112,6 +113,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
     if (Double.compare(that.slaveCpus, slaveCpus) != 0) return false;
     if (slaveMem != that.slaveMem) return false;
     if (Double.compare(that.executorCpus, executorCpus) != 0) return false;
+    if (Double.compare(that.diskNeeded, diskNeeded) !=0 ) return false;
     if (minExecutors != that.minExecutors) return false;
     if (maxExecutors != that.maxExecutors) return false;
     if (executorMem != that.executorMem) return false;
@@ -139,6 +141,8 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
     result = 31 * result + slaveMem;
     temp = Double.doubleToLongBits(executorCpus);
     result = 31 * result + (int) (temp ^ (temp >>> 32));
+    temp = Double.doubleToLongBits(diskNeeded);
+    result = 31 * result + (int) (temp ^ (temp >>> 32));
     result = 31 * result + minExecutors;
     result = 31 * result + maxExecutors;
     result = 31 * result + executorMem;
@@ -164,6 +168,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
       String minExecutors,
       String maxExecutors,
       String executorCpus,
+      String diskNeeded,
       String executorMem,
       String remoteFSRoot,
       String idleTerminationMinutes,
@@ -184,6 +189,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
               Integer.parseInt(minExecutors),
               Integer.parseInt(maxExecutors),
               Double.parseDouble(executorCpus),
+              Double.parseDouble(diskNeeded),
               Integer.parseInt(executorMem),
               StringUtils.isNotBlank(remoteFSRoot) ? remoteFSRoot.trim() : "jenkins",
               Integer.parseInt(idleTerminationMinutes),
@@ -204,6 +210,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
       int minExecutors,
       int maxExecutors,
       double executorCpus,
+      double diskNeeded,
       int executorMem,
       String remoteFSRoot,
       int idleTerminationMinutes,
@@ -222,6 +229,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
       this.minExecutors = minExecutors < 1 ? 1 : minExecutors; // Ensure minExecutors is at least equal to 1
       this.maxExecutors = maxExecutors;
       this.executorCpus = executorCpus;
+      this.diskNeeded = diskNeeded;
       this.executorMem = executorMem;
       this.remoteFSRoot = remoteFSRoot;
       this.idleTerminationMinutes = idleTerminationMinutes;
@@ -246,6 +254,10 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
     return null;
   }
 
+  public double getdiskNeeded() {
+    return diskNeeded;
+  }
+
   public MesosSlaveInfo copyWithDockerImage(String label, String dockerImage) {
     LOGGER.fine(String.format("Customize mesos slave %s using docker image %s", this.getLabelString(), dockerImage));
 
@@ -258,6 +270,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
               minExecutors,
               maxExecutors,
               executorCpus,
+              diskNeeded,
               executorMem,
               remoteFSRoot,
               idleTerminationMinutes,

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/config.jelly
@@ -45,6 +45,10 @@
         <f:textbox clazz="required" default="jenkins"/>
     </f:entry>
 
+    <f:entry title="${%Disk Space in MB}" field="diskNeeded">
+        <f:textbox clazz="required" default="0.0"/>
+    </f:entry>
+
     <f:entry title="${%Idle Termination Minutes}" field="idleTerminationMinutes">
         <f:number clazz="required number" default="3"/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/help-diskNeeded.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/help-diskNeeded.html
@@ -1,0 +1,3 @@
+<div>
+    Specify amount of disk needed. If you don't want to add disk constraint on the offers, set it to 0.0.<br>
+</div>

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -429,6 +429,7 @@ public class JenkinsSchedulerTest {
                 "1",                // minExecutors,
                 "2",                // maxExecutors,
                 "0.2",              // executorCpus,
+                "500",               // diskNeeded
                 "512",              // executorMem,
                 "remoteFSRoot",     // remoteFSRoot,
                 "2",                // idleTerminationMinutes,
@@ -441,7 +442,7 @@ public class JenkinsSchedulerTest {
                 null              // nodeProperties
                 );
         return new Mesos.SlaveRequest(
-            new Mesos.JenkinsSlave(TEST_JENKINS_SLAVE_NAME), 0.2d, TEST_JENKINS_SLAVE_MEM, "jenkins", mesosSlaveInfo);
+            new Mesos.JenkinsSlave(TEST_JENKINS_SLAVE_NAME), 0.2d, TEST_JENKINS_SLAVE_MEM, "jenkins", mesosSlaveInfo, 500);
     }
 
     private JenkinsScheduler.Request mockMesosRequest(

--- a/src/test/java/org/jenkinsci/plugins/mesos/MesosSlaveInfoTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/MesosSlaveInfoTest.java
@@ -81,6 +81,7 @@ public class MesosSlaveInfoTest {
                 "1",
                 "1",
                 "1",
+                "500",
                 "1",
                 "",
                 "1",


### PR DESCRIPTION
This option could be customized at slave level and hence
plugin would only accept resources that has the specified
amount in MB as Disk resource available. The option is
ignored for Docker containerizer and if the value is set
to 0.

This opens up up the killing of mesos slave if the slave
uses more that alloted amount of disk space by setting
--isolation with disk/du and
--enforce-container-disk-quota