### PR TITLE
Allow tunnel option in slave config

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -14,6 +14,8 @@
  */
 package org.jenkinsci.plugins.mesos;
 
+import com.google.common.net.HostAndPort;
+
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -847,6 +849,21 @@ public void setJenkinsURL(String jenkinsURL) {
       String errorMessage = "Invalid Remote FS Root - should be non-empty. It will be defaulted to \"jenkins\".";
 
       return StringUtils.isNotBlank(value) ? FormValidation.ok() : FormValidation.error(errorMessage);
+    }
+
+    public FormValidation doCheckTunnel(@QueryParameter String value) {
+      final HostAndPort hostAndPort;
+      try {
+        hostAndPort = HostAndPort.fromString(value);
+      } catch (IllegalArgumentException e) {
+        return FormValidation.error(e, e.getMessage());
+      }
+
+      if (!hostAndPort.hasPort()) {
+        return FormValidation.error("Invalid tunnel, port must be specified.");
+      }
+
+      return FormValidation.ok();
     }
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosComputerLauncher.java
@@ -14,15 +14,15 @@
  */
 package org.jenkinsci.plugins.mesos;
 
-import hudson.model.TaskListener;
-import hudson.slaves.JNLPLauncher;
-import hudson.slaves.SlaveComputer;
+import org.jenkinsci.plugins.mesos.Mesos.JenkinsSlave;
 
 import java.io.PrintStream;
 import java.util.concurrent.CountDownLatch;
 import java.util.logging.Logger;
 
-import org.jenkinsci.plugins.mesos.Mesos.JenkinsSlave;
+import hudson.model.TaskListener;
+import hudson.slaves.JNLPLauncher;
+import hudson.slaves.SlaveComputer;
 
 public class MesosComputerLauncher extends JNLPLauncher {
 
@@ -33,7 +33,7 @@ public class MesosComputerLauncher extends JNLPLauncher {
   private static final Logger LOGGER = Logger.getLogger(MesosComputerLauncher.class.getName());
 
   public MesosComputerLauncher(MesosCloud cloud, String _name) {
-    super();
+    super(cloud.getTunnel(), null);
     LOGGER.finer("Constructing MesosComputerLauncher");
     this.cloud = cloud;
     this.state = State.INIT;

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -44,7 +44,7 @@
             <st:nbsp/>${%No}
         </f:entry>
 
-        <f:entry title="${%Jenkins tunnel }" field="tunnel">
+        <f:entry title="${%Jenkins tunnel }" description="${%HOST:PORT connect to this agent host and port instead of Jenkins server, assuming this one can route TCP traffic to Jenkins master. Useful when when Jenkins runs behind a load balancer, reverse proxy, etc.}" field="tunnel">
             <f:textbox/>
         </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -44,6 +44,10 @@
             <st:nbsp/>${%No}
         </f:entry>
 
+        <f:entry title="${%Jenkins tunnel }" field="tunnel">
+            <f:textbox/>
+        </f:entry>
+
         <f:entry title="${%On-demand framework registration}" field="onDemandRegistration" description="${%Enable to make this cloud register as a framework when builds need to be performed. And, disconnect otherwise.}">
             <f:radio name="onDemandRegistration" value="true" checked="${instance == null || instance.onDemandRegistration == true}" id="onDemandRegistration.true"/>
             <st:nbsp/>${%Yes}

--- a/src/test/java/org/jenkinsci/plugins/mesos/MesosCloudDescriptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/MesosCloudDescriptorTest.java
@@ -1,0 +1,41 @@
+package org.jenkinsci.plugins.mesos;
+
+import org.junit.Test;
+
+import hudson.util.FormValidation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MesosCloudDescriptorTest {
+  @Test
+  public void tunnelMustHaveColonSeparator() throws Exception {
+    FormValidation formValidation = new MesosCloud.DescriptorImpl()
+        .doCheckTunnel("127.0.0.1,3333");
+
+    assertThat(formValidation.kind).isEqualByComparingTo(FormValidation.Kind.ERROR);
+  }
+
+  @Test
+  public void tunnelMustHaveValidPort() throws Exception {
+    FormValidation formValidation = new MesosCloud.DescriptorImpl()
+        .doCheckTunnel("127.0.0.1:99999");
+
+    assertThat(formValidation.kind).isEqualByComparingTo(FormValidation.Kind.ERROR);
+  }
+
+  @Test
+  public void tunnelMustHavePort() throws Exception {
+    FormValidation formValidation = new MesosCloud.DescriptorImpl()
+        .doCheckTunnel("127.0.0.1");
+
+    assertThat(formValidation.kind).isEqualByComparingTo(FormValidation.Kind.ERROR);
+  }
+
+  @Test
+  public void validTunnelString() throws Exception {
+    FormValidation formValidation = new MesosCloud.DescriptorImpl()
+        .doCheckTunnel("127.0.0.1:8080");
+
+    assertThat(formValidation.kind).isEqualByComparingTo(FormValidation.Kind.OK);
+  }
+}


### PR DESCRIPTION
Currently, if you use the plugin you're limited to going to the default setup for a JSlave.  That doesn't work in all scenarios, especially ours.  We need to add in the Jenkins tunnel parameter to the JSlave that is started.  See JENKINS_TUNNEL for this Docker image for more infromation: https://hub.docker.com/r/jenkinsci/jnlp-slave/