### PR TITLE
Replace invalid hostname characters for task names and docker hostname

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -431,7 +431,7 @@ public class JenkinsScheduler implements Scheduler {
 
     @VisibleForTesting
     void startProcessing() {
-        String threadName = "mesos-offer-processor-" + getFrameworkId();
+        final String threadName = "mesos-offer-processor-" + getFrameworkId();
         LOGGER.info("Starting offer processing thread: " + threadName);
 
         offerProcessingThread = new Thread(new Runnable() {


### PR DESCRIPTION
Before this change, if you used the mesos plugin option 'Docker Image Can Be Customized'
and the resulting task name was less than 64 characters it could happen that the docker
image name contained invalid characters both for the task name and the docker hostname.
For example a custom label:foo/bar:latest would fail as a task name because / is invalid
in a task name since it breaks the directory structure. It would also fail as a docker
hostname since it needs to comply with RFC 1123 hostnames

Original commit was to fix https://github.com/jenkinsci/mesos-plugin/issues/251