### PR TITLE
Added a licensing definition to the Maven project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,14 @@
     <tag>HEAD</tag>
   </scm>
 
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://github.com/jenkinsci/mesos-plugin/raw/master/LICENSE</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <developers>
     <developer>
       <id>benh</id>


### PR DESCRIPTION
In order to meet the [prerequisites](https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins#HostingPlugins-Prerequisites) of plugin hosting in the Jenkins Organization, I'm adding the licensing definition in the Maven project.

@reviewbybees, What do you think?
