### PR TITLE
[JENKINS-49117] - Stop serializing ReentrantLocks to the disk

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Build the plugin using https://github.com/jenkins-infra/pipeline-library
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.19</version>
+    <version>3.2</version>
   </parent>
 
   <artifactId>mesos</artifactId>
@@ -91,8 +91,8 @@
   </pluginRepositories>
 
   <properties>
-    <jenkins.version>1.599</jenkins.version>
-    <jenkins-test-harness.version>1.599</jenkins-test-harness.version>
+    <jenkins.version>2.7.3</jenkins.version>
+    <java.level>7</java.level>
     <findbugs.failOnError>false</findbugs.failOnError>
     <mesos.version>1.0.0</mesos.version>
     <protobuf.version>2.6.1</protobuf.version>
@@ -142,6 +142,12 @@
           <version>${powermock.version}</version>
           <scope>test</scope>
       </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
       <dependency>
           <groupId>org.assertj</groupId>
           <artifactId>assertj-core</artifactId>
@@ -169,20 +175,8 @@
   <build>
       <plugins>
           <plugin>
-              <artifactId>maven-release-plugin</artifactId>
-              <version>2.5.3</version>
-          </plugin>
-          <plugin>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                  <target>1.6</target>
-                  <source>1.6</source>
-              </configuration>
-          </plugin>
-          <plugin>
               <groupId>org.jenkins-ci.tools</groupId>
               <artifactId>maven-hpi-plugin</artifactId>
-              <version>1.117</version>
               <configuration>
                   <systemProperties>
                       <hudson.slaves.NodeProvisioner.initialDelay>0</hudson.slaves.NodeProvisioner.initialDelay>


### PR DESCRIPTION
It includes #309 for testing purposes and includes a hotfix for https://issues.jenkins-ci.org/browse/JENKINS-49117 to make the plugin compatible with Jenkins 2.102+

@reviewbybees @jglick 



