### PR TITLE
[JENKINS-50303] Using XStream to serialize a JSONObject was never advisable and as of 2.102 is forbidden

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin()
+buildPlugin(jenkinsVersions: [null, '2.107.1'])

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>mesos</artifactId>
-  <version>0.15.2-SNAPSHOT</version>
+  <version>0.16-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Mesos+Plugin</url>
   <description>Allows the dynamic launch Jenkins agent on a Mesos cluster, depending on workload</description>
@@ -188,6 +188,7 @@
               <groupId>org.jenkins-ci.tools</groupId>
               <artifactId>maven-hpi-plugin</artifactId>
               <configuration>
+                  <compatibleSinceVersion>0.16</compatibleSinceVersion>
                   <systemProperties>
                       <hudson.slaves.NodeProvisioner.initialDelay>0</hudson.slaves.NodeProvisioner.initialDelay>
                   </systemProperties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.2</version>
+    <version>3.6</version>
+    <relativePath />
   </parent>
 
   <artifactId>mesos</artifactId>
@@ -97,7 +98,7 @@
     <mesos.version>1.0.0</mesos.version>
     <protobuf.version>2.6.1</protobuf.version>
     <mockito.version>1.10.19</mockito.version>
-    <powermock.version>1.6.2</powermock.version>
+    <powermock.version>1.6.6</powermock.version>
     <assertj.version>2.1.0</assertj.version>
     <guava.version>18.0</guava.version>
     <apache-commons-collections.version>4.1</apache-commons-collections.version>
@@ -171,6 +172,15 @@
           <optional>true</optional>
       </dependency>
   </dependencies>
+  <dependencyManagement>
+      <dependencies>
+          <dependency>
+              <groupId>org.objenesis</groupId>
+              <artifactId>objenesis</artifactId>
+              <version>2.4</version>
+          </dependency>
+      </dependencies>
+  </dependencyManagement>
 
   <build>
       <plugins>

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
@@ -14,8 +14,7 @@
  */
 package org.jenkinsci.plugins.mesos;
 
-import static hudson.util.TimeUnit2.MINUTES;
-
+import static java.util.concurrent.TimeUnit.MINUTES;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -90,6 +90,8 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
   private final boolean defaultSlave;
   // Slave attributes JSON representation.
   private final String slaveAttributesString;
+  @Deprecated
+  private final JSONObject slaveAttributes;
   private final ContainerInfo containerInfo;
   private final List<URI> additionalURIs;
   private final Mode mode;
@@ -250,6 +252,14 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
     }
 
     return null;
+  }
+
+  private Object readResolve() {
+      if (slaveAttributes != null) {
+          slaveAttributesString = slaveAttributes.toString();
+          slaveAttributes = null;
+      }
+      return this;
   }
 
   public double getdiskNeeded() {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -91,7 +91,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
   // Slave attributes JSON representation.
   private String slaveAttributesString;
   @Deprecated
-  private JSONObject slaveAttributes;
+  private transient JSONObject slaveAttributes;
   private final ContainerInfo containerInfo;
   private final List<URI> additionalURIs;
   private final Mode mode;

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -89,9 +89,9 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
   private final String jnlpArgs;
   private final boolean defaultSlave;
   // Slave attributes JSON representation.
-  private final String slaveAttributesString;
+  private String slaveAttributesString;
   @Deprecated
-  private final JSONObject slaveAttributes;
+  private JSONObject slaveAttributes;
   private final ContainerInfo containerInfo;
   private final List<URI> additionalURIs;
   private final Mode mode;
@@ -254,14 +254,6 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
     return null;
   }
 
-  private Object readResolve() {
-      if (slaveAttributes != null) {
-          slaveAttributesString = slaveAttributes.toString();
-          slaveAttributes = null;
-      }
-      return this;
-  }
-
   public double getdiskNeeded() {
     return diskNeeded;
   }
@@ -414,6 +406,10 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
     }
     if (minExecutors == 0) {
       this.minExecutors = 1;
+    }
+    if (slaveAttributes != null) {
+      slaveAttributesString = slaveAttributes.toString();
+      slaveAttributes = null;
     }
     return this;
   }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -28,8 +28,6 @@ import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.mesos.Protos;
-import org.apache.mesos.Protos.NetworkInfo.Protocol;
 import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -91,7 +89,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
   private final String jnlpArgs;
   private final boolean defaultSlave;
   // Slave attributes JSON representation.
-  private final JSONObject slaveAttributes;
+  private final String slaveAttributesString;
   private final ContainerInfo containerInfo;
   private final List<URI> additionalURIs;
   private final Mode mode;
@@ -121,7 +119,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
     if (remoteFSRoot != null ? !remoteFSRoot.equals(that.remoteFSRoot) : that.remoteFSRoot != null) return false;
     if (jvmArgs != null ? !jvmArgs.equals(that.jvmArgs) : that.jvmArgs != null) return false;
     if (jnlpArgs != null ? !jnlpArgs.equals(that.jnlpArgs) : that.jnlpArgs != null) return false;
-    if (slaveAttributes != null ? !slaveAttributes.equals(that.slaveAttributes) : that.slaveAttributes != null)
+    if (slaveAttributesString != null ? !slaveAttributesString.equals(that.slaveAttributesString) : that.slaveAttributesString != null)
       return false;
     if (containerInfo != null ? !containerInfo.equals(that.containerInfo) : that.containerInfo != null) return false;
     if (additionalURIs != null ? !additionalURIs.equals(that.additionalURIs) : that.additionalURIs != null)
@@ -150,7 +148,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
     result = 31 * result + idleTerminationMinutes;
     result = 31 * result + (jvmArgs != null ? jvmArgs.hashCode() : 0);
     result = 31 * result + (jnlpArgs != null ? jnlpArgs.hashCode() : 0);
-    result = 31 * result + (slaveAttributes != null ? slaveAttributes.hashCode() : 0);
+    result = 31 * result + (slaveAttributesString != null ? slaveAttributesString.hashCode() : 0);
     result = 31 * result + (containerInfo != null ? containerInfo.hashCode() : 0);
     result = 31 * result + (additionalURIs != null ? additionalURIs.hashCode() : 0);
     result = 31 * result + (mode != null ? mode.hashCode() : 0);
@@ -233,7 +231,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
       this.executorMem = executorMem;
       this.remoteFSRoot = remoteFSRoot;
       this.idleTerminationMinutes = idleTerminationMinutes;
-      this.slaveAttributes = slaveAttributes;
+      this.slaveAttributesString = slaveAttributes != null ? slaveAttributes.toString() : null;
       this.jvmArgs = jvmArgs;
       this.jnlpArgs = jnlpArgs;
       this.defaultSlave = defaultSlave;
@@ -274,7 +272,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
               executorMem,
               remoteFSRoot,
               idleTerminationMinutes,
-              slaveAttributes,
+              parseSlaveAttributes(slaveAttributesString),
               jvmArgs,
               jnlpArgs,
               defaultSlave,
@@ -333,7 +331,7 @@ public class MesosSlaveInfo extends AbstractDescribableImpl<MesosSlaveInfo> {
   }
 
   public JSONObject getSlaveAttributes() {
-    return slaveAttributes;
+    return parseSlaveAttributes(slaveAttributesString);
   }
 
   public String getJvmArgs() {

--- a/src/test/java/org/jenkinsci/plugins/mesos/MesosCloudTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/MesosCloudTest.java
@@ -21,6 +21,7 @@ import hudson.model.Node;
 import hudson.slaves.NodeProperty;
 import java.io.File;
 import java.util.Collections;
+import java.util.List;
 import jenkins.model.Jenkins;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
@@ -28,6 +29,7 @@ import org.junit.Test;
 import org.junit.Rule;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 public class MesosCloudTest {
 
@@ -54,6 +56,16 @@ public class MesosCloudTest {
         r.configRoundtrip();
         r.assertEqualDataBoundBeans(Collections.singletonList(cloud), r.jenkins.clouds);
         assertThat(new XmlFile(Jenkins.XSTREAM, new File(r.jenkins.root, "config.xml")).asString(), containsString(slaveAttributes.replace("\"", "&quot;")));
+    }
+
+    @Issue("JENKINS-50303")
+    @LocalData
+    @Test
+    public void oldData() throws Exception {
+        assertEquals(1, r.jenkins.clouds.size());
+        List<MesosSlaveInfo> slaveInfos = ((MesosCloud) r.jenkins.clouds.get(0)).getSlaveInfos();
+        assertEquals(1, slaveInfos.size());
+        assertThat(String.valueOf(slaveInfos.get(0).getSlaveAttributes()), anyOf(is("{\"x\":\"y\"}"), is("null")));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/mesos/MesosCloudTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/MesosCloudTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jenkinsci.plugins.mesos;
+
+import hudson.XmlFile;
+import hudson.model.Node;
+import hudson.slaves.NodeProperty;
+import java.io.File;
+import java.util.Collections;
+import jenkins.model.Jenkins;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.Rule;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class MesosCloudTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Issue("JENKINS-50303")
+    @Test
+    public void configRoundtrip() throws Exception {
+        String slaveAttributes = "{\"somekey\":\"somevalue\"}";
+        MesosCloud cloud = new MesosCloud(
+            "<nativeLibraryPath>", "<master>", "<description>", "<frameworkName>", "<role>", "<slavesUser>", "", "<principal>", /* TODO why is secret still in the DBC?? */null,
+            Collections.singletonList(new MesosSlaveInfo("<labelString>", Node.Mode.NORMAL, "4", "1024", "1", "1", "1", "0.0", "1024", "<remoteFSRoot>", "1", slaveAttributes, "<jvmArgs>", "<jnlpArgs>", "<defaultSlave>",
+                    new MesosSlaveInfo.ContainerInfo(/* not actually used, should really be using f:optionalProperty */"DOCKER", "<dockerImage>", true, true, true, true, "<customDockerCommandShell>",
+                            Collections.singletonList(new MesosSlaveInfo.Volume("<containerPath>", "<hostPath>", true)),
+                            Collections.singletonList(new MesosSlaveInfo.Parameter("<key>", "<value>")),
+                            "BRIDGE",
+                            Collections.singletonList(new MesosSlaveInfo.PortMapping(23, 46, "udp")),
+                            Collections.singletonList(new MesosSlaveInfo.NetworkInfo("<networkName>"))),
+                    Collections.singletonList(new MesosSlaveInfo.URI("<value>", true, true)),
+                    Collections.<NodeProperty<?>>emptyList())),
+            true, true, "<jenkinsURL>", "1234", "<cloudID>");
+        r.jenkins.clouds.add(cloud);
+        r.configRoundtrip();
+        r.assertEqualDataBoundBeans(Collections.singletonList(cloud), r.jenkins.clouds);
+        assertThat(new XmlFile(Jenkins.XSTREAM, new File(r.jenkins.root, "config.xml")).asString(), containsString(slaveAttributes.replace("\"", "&quot;")));
+    }
+
+}

--- a/src/test/resources/org/jenkinsci/plugins/mesos/MesosCloudTest/oldData/config.xml
+++ b/src/test/resources/org/jenkinsci/plugins/mesos/MesosCloudTest/oldData/config.xml
@@ -1,0 +1,88 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>2.7.3</version>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+  <securityRealm class="hudson.security.SecurityRealm$None"/>
+  <disableRememberMe>false</disableRememberMe>
+  <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+  <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds>
+    <org.jenkinsci.plugins.mesos.MesosCloud plugin="mesos@0.15.2-SNAPSHOT">
+      <name>MesosCloud</name>
+      <nativeLibraryPath></nativeLibraryPath>
+      <master></master>
+      <description></description>
+      <frameworkName>Jenkins Scheduler</frameworkName>
+      <role>*</role>
+      <slavesUser></slavesUser>
+      <credentialsId></credentialsId>
+      <cloudID>79262570-adf9-40b3-b403-f68e8b1fbfa0</cloudID>
+      <checkpoint>false</checkpoint>
+      <onDemandRegistration>true</onDemandRegistration>
+      <jenkinsURL></jenkinsURL>
+      <declineOfferDuration>600000</declineOfferDuration>
+      <slaveInfos>
+        <org.jenkinsci.plugins.mesos.MesosSlaveInfo>
+          <slaveCpus>0.1</slaveCpus>
+          <diskNeeded>0.0</diskNeeded>
+          <slaveMem>512</slaveMem>
+          <executorCpus>0.1</executorCpus>
+          <minExecutors>1</minExecutors>
+          <maxExecutors>2</maxExecutors>
+          <executorMem>128</executorMem>
+          <remoteFSRoot>jenkins</remoteFSRoot>
+          <idleTerminationMinutes>3</idleTerminationMinutes>
+          <jvmArgs>-Xms16m -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true</jvmArgs>
+          <jnlpArgs>-noReconnect</jnlpArgs>
+          <defaultSlave>false</defaultSlave>
+          <slaveAttributes>
+            <nullObject>false</nullObject>
+            <properties class="org.apache.commons.collections.map.ListOrderedMap" serialization="custom">
+              <unserializable-parents/>
+              <org.apache.commons.collections.map.ListOrderedMap>
+                <default>
+                  <insertOrder>
+                    <string>x</string>
+                  </insertOrder>
+                </default>
+                <map>
+                  <entry>
+                    <string>x</string>
+                    <string>y</string>
+                  </entry>
+                </map>
+              </org.apache.commons.collections.map.ListOrderedMap>
+            </properties>
+          </slaveAttributes>
+          <mode>NORMAL</mode>
+          <nodeProperties/>
+          <labelString>mesos</labelString>
+        </org.jenkinsci.plugins.mesos.MesosSlaveInfo>
+      </slaveInfos>
+    </org.jenkinsci.plugins.mesos.MesosCloud>
+  </clouds>
+  <quietPeriod>5</quietPeriod>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>All</primaryView>
+  <slaveAgentPort>0</slaveAgentPort>
+  <label></label>
+  <nodeProperties/>
+  <globalNodeProperties/>
+</hudson>


### PR DESCRIPTION
[JENKINS-50303](https://issues.jenkins-ci.org/browse/JENKINS-50303). Follows up #310.

Does not attempt to load historical `slaveAttributes` settings. They will just need to be reconfigured. Since there are barely over a thousand registered users of this plugin, and this field was in an **Advanced** block to begin with, I figure release notes should suffice.

@reviewbybees esp. @oleg-nenashev @Vlatombe