### PR TITLE
Fix offer handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 
   <properties>
     <jenkins.version>2.7.3</jenkins.version>
-    <java.level>7</java.level>
+    <java.level>8</java.level>
     <findbugs.failOnError>false</findbugs.failOnError>
     <mesos.version>1.0.0</mesos.version>
     <protobuf.version>2.6.1</protobuf.version>

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -941,6 +941,7 @@ public class JenkinsScheduler implements Scheduler {
     @Override
     public void offerRescinded(SchedulerDriver driver, OfferID offerId) {
         LOGGER.info("Rescinded offer " + offerId);
+        offerQueue.remove(offerId);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -18,34 +18,10 @@ package org.jenkinsci.plugins.mesos;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.google.common.annotations.VisibleForTesting;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.util.Secret;
-
-import java.lang.Math;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.collections4.OrderedMapIterator;
@@ -53,835 +29,858 @@ import org.apache.commons.collections4.map.LRUMap;
 import org.apache.commons.lang.StringUtils;
 import org.apache.mesos.MesosSchedulerDriver;
 import org.apache.mesos.Protos;
-import org.apache.mesos.Protos.NetworkInfo;
-import org.apache.mesos.Protos.Attribute;
-import org.apache.mesos.Protos.CommandInfo;
-import org.apache.mesos.Protos.ContainerInfo;
+import org.apache.mesos.Protos.*;
 import org.apache.mesos.Protos.ContainerInfo.DockerInfo;
 import org.apache.mesos.Protos.ContainerInfo.DockerInfo.Network;
 import org.apache.mesos.Protos.ContainerInfo.DockerInfo.PortMapping;
-import org.apache.mesos.Protos.Credential;
-import org.apache.mesos.Protos.ExecutorID;
-import org.apache.mesos.Protos.Filters;
-import org.apache.mesos.Protos.FrameworkID;
-import org.apache.mesos.Protos.FrameworkInfo;
-import org.apache.mesos.Protos.MasterInfo;
-import org.apache.mesos.Protos.Offer;
-import org.apache.mesos.Protos.OfferID;
-import org.apache.mesos.Protos.Parameter;
-import org.apache.mesos.Protos.Resource;
-import org.apache.mesos.Protos.SlaveID;
-import org.apache.mesos.Protos.Status;
-import org.apache.mesos.Protos.TaskID;
-import org.apache.mesos.Protos.TaskInfo;
-import org.apache.mesos.Protos.TaskStatus;
-import org.apache.mesos.Protos.Value;
 import org.apache.mesos.Protos.Value.Range;
-import org.apache.mesos.Protos.Volume;
 import org.apache.mesos.Protos.Volume.Mode;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public class JenkinsScheduler implements Scheduler {
-  private static final String SLAVE_JAR_URI_SUFFIX = "jnlpJars/slave.jar";
+    private static final String SLAVE_JAR_URI_SUFFIX = "jnlpJars/slave.jar";
 
-  /**
-   * When created, we expect this scheduler to live for at least 1 minute before killing it.
-   * This prevents race conditions between threads provisioning new nodes and threads terminating them.
-   */
-  private static final Long MINIMUM_TIME_TO_LIVE = TimeUnit.MINUTES.toMillis(1);
-
-  // We allocate 10% more memory to the Mesos task to account for the JVM overhead.
-  private static final double JVM_MEM_OVERHEAD_FACTOR = 0.1;
-
-  private static final String SLAVE_COMMAND_FORMAT =
-      "java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar ${MESOS_SANDBOX-.}/slave.jar %s %s -jnlpUrl %s";
-  private static final String JNLP_SECRET_FORMAT = "-secret %s";
-  public static final String PORT_RESOURCE_NAME = "ports";
-  public static final String MESOS_DEFAULT_ROLE = "*";
-
-  private Queue<Request> requests;
-  private Set<String> unmatchedLabels;
-  private Map<TaskID, Result> results;
-  private Set<TaskID> finishedTasks;
-  private volatile SchedulerDriver driver;
-  private String jenkinsMaster;
-  private volatile MesosCloud mesosCloud;
-  private volatile boolean running;
-
-  private long startedTime;
-
-  private static final Logger LOGGER = Logger.getLogger(JenkinsScheduler.class.getName());
-
-  public static final Lock SUPERVISOR_LOCK = new ReentrantLock();
-
-  private static int lruCacheSize = Integer.getInteger(JenkinsScheduler.class.getName()+".lruCacheSize", 10);
-
-  private static LRUMap<String, Object> recentlyAcceptedOffers = new LRUMap<String, Object>(lruCacheSize);
-
-  private static final Object IGNORE = new Object();
-
-  public JenkinsScheduler(String jenkinsMaster, MesosCloud mesosCloud) {
-    startedTime = System.currentTimeMillis();
-    LOGGER.info("JenkinsScheduler instantiated with jenkins " + jenkinsMaster + " and mesos " + mesosCloud.getMaster());
-
-    this.jenkinsMaster = jenkinsMaster;
-    this.mesosCloud = mesosCloud;
-
-    requests = new LinkedList<Request>();
-    unmatchedLabels = new HashSet<String>();
-    results = new HashMap<TaskID, Result>();
-    finishedTasks = Collections.newSetFromMap(new ConcurrentHashMap<TaskID, Boolean>());
-  }
-
-  public synchronized void init() {
-    // This is to ensure that isRunning() returns true even when the driver is not yet inside run().
-    // This is important because MesosCloud.provision() starts a new framework whenever isRunning() is false.
-    running = true;
-    String targetUser = mesosCloud.getSlavesUser();
-    String webUrl = getJenkins().getRootUrl();
-    if (webUrl == null) webUrl = System.getenv("JENKINS_URL");
-    StandardUsernamePasswordCredentials credentials = mesosCloud.getCredentials();
-    String principal = credentials == null ? "jenkins" : credentials.getUsername();
-    String secret = credentials == null ? "" : Secret.toString(credentials.getPassword());
-    // Have Mesos fill in the current user.
-    FrameworkInfo framework = FrameworkInfo.newBuilder()
-            .setUser(targetUser == null ? "" : targetUser)
-            .setName(mesosCloud.getFrameworkName())
-            .setRole(mesosCloud.getRole())
-            .setPrincipal(principal)
-            .setCheckpoint(mesosCloud.isCheckpoint())
-            .setWebuiUrl(webUrl != null ? webUrl : "")
-            .build();
-
-    LOGGER.info("Initializing the Mesos driver with options"
-            + "\n" + "Framework Name: " + framework.getName()
-            + "\n" + "Principal: " + principal
-            + "\n" + "Checkpointing: " + framework.getCheckpoint()
-    );
-
-    if (StringUtils.isNotBlank(secret)) {
-
-      Credential credential = Credential.newBuilder()
-              .setPrincipal(principal)
-              .setSecret(secret)
-              .build();
-
-      LOGGER.info("Authenticating with Mesos master with principal " + credential.getPrincipal());
-      driver = new MesosSchedulerDriver(JenkinsScheduler.this, framework, mesosCloud.getMaster(), credential);
-    } else {
-      driver = new MesosSchedulerDriver(JenkinsScheduler.this, framework, mesosCloud.getMaster());
-    }
-    // Start the framework.
-    new Thread(new Runnable() {
-      @Override
-      public void run() {
-        try {
-          Status runStatus = driver.run();
-          if (runStatus != Status.DRIVER_STOPPED) {
-            LOGGER.severe("The Mesos driver was aborted! Status code: " + runStatus.getNumber());
-          } else {
-            LOGGER.info("The Mesos driver was stopped.");
-          }
-        } catch(RuntimeException e) {
-          LOGGER.log(Level.SEVERE, "Caught a RuntimeException", e);
-        } finally {
-          SUPERVISOR_LOCK.lock();
-          if (driver != null) {
-            driver.abort();
-          }
-          driver = null;
-          running = false;
-          SUPERVISOR_LOCK.unlock();
-        }
-      }
-    }).start();
-  }
-
-  public synchronized void stop() {
-    try {
-      SUPERVISOR_LOCK.lock();
-      if (driver != null) {
-        LOGGER.info("Stopping Mesos driver.");
-        driver.stop();
-      } else {
-        LOGGER.warning("Unable to stop Mesos driver:  driver is null.");
-      }
-      running = false;
-    } finally {
-      SUPERVISOR_LOCK.unlock();
-    }
-  }
-
-  public synchronized boolean isRunning() {
-    return running;
-  }
-
-  public synchronized void requestJenkinsSlave(Mesos.SlaveRequest request, Mesos.SlaveResult result) {
-    LOGGER.fine("Enqueuing jenkins slave request");
-    requests.add(new Request(request, result));
-    if (driver != null) {
-      // Ask mesos to send all offers, even the those we declined earlier.
-      // See comment in resourceOffers() for further details.
-      driver.reviveOffers();
-    }
-  }
-
-  public boolean reachedMinimumTimeToLive() {
-    return System.currentTimeMillis() - startedTime > MINIMUM_TIME_TO_LIVE;
-  }
-
-  /**
-   * @param slaveName the slave name in jenkins
-   * @return the jnlp url for the slave: http://[master]/computer/[slaveName]/slave-agent.jnlp
-   */
-  private String getJnlpUrl(String slaveName) {
-    return joinPaths(joinPaths(joinPaths(jenkinsMaster, "computer"), slaveName), "slave-agent.jnlp");
-  }
-
-  /**
-   * Slave needs to go through authentication while connecting through jnlp if security is enabled in jenkins.
-   * This method gets secret (for jnlp authentication) from jenkins, constructs command line argument and returns it.
-   *
-   * @param slaveName the slave name in jenkins
-   * @return jenkins slave secret corresponding to slave name in the format '-secret <secret>'
-   */
-  private String getJnlpSecret(String slaveName) {
-    String jnlpSecret = "";
-    if(getJenkins().isUseSecurity()) {
-      jnlpSecret = String.format(JNLP_SECRET_FORMAT, jenkins.slaves.JnlpSlaveAgentProtocol.SLAVE_SECRET.mac(slaveName));
-    }
-    return jnlpSecret;
-  }
-
-  private static String joinPaths(String prefix, String suffix) {
-    if (prefix.endsWith("/"))   prefix = prefix.substring(0, prefix.length()-1);
-    if (suffix.startsWith("/")) suffix = suffix.substring(1, suffix.length());
-
-    return prefix + '/' + suffix;
-  }
-
-  public synchronized void terminateJenkinsSlave(String name) {
-    LOGGER.info("Terminating jenkins slave " + name);
-
-    TaskID taskId = TaskID.newBuilder().setValue(name).build();
-
-    if (results.containsKey(taskId)) {
-      LOGGER.info("Killing mesos task " + taskId);
-      driver.killTask(taskId);
-    } else {
-        // This is handling the situation that a slave was provisioned but it never
-        // got scheduled because of resource scarcity and jenkins later tries to remove
-        // the offline slave but since it was not scheduled we have to remove it from
-        // the request queue. The method has been also synchronized because there is a race
-        // between this removal request from jenkins and a resource getting freed up in mesos
-        // resulting in scheduling the slave and resulting in orphaned task/slave not monitored
-        // by Jenkins.
-
-        for(Request request : requests) {
-           if(request.request.slave.name.equals(name)) {
-             LOGGER.info("Removing enqueued mesos task " + name);
-             requests.remove(request);
-             // Also signal the Thread of the MesosComputerLauncher.launch() to exit from latch.await()
-             // Otherwise the Thread will stay in WAIT forever -> Leak!
-             request.result.failed(request.request.slave);
-             return;
-           }
-        }
-
-        LOGGER.warning("Asked to kill unknown mesos task " + taskId);
-    }
-
-    // Since this task is now running, we should not start this task up again at a later point in time
-    finishedTasks.add(taskId);
-
-    if (mesosCloud.isOnDemandRegistration()) {
-      supervise();
-    }
-
-  }
-
-  @Override
-  public void registered(SchedulerDriver driver, FrameworkID frameworkId, MasterInfo masterInfo) {
-    LOGGER.info("Framework registered! ID = " + frameworkId.getValue());
-  }
-
-  @Override
-  public void reregistered(SchedulerDriver driver, MasterInfo masterInfo) {
-    LOGGER.info("Framework re-registered");
-  }
-
-  @Override
-  public void disconnected(SchedulerDriver driver) {
-    LOGGER.info("Framework disconnected!");
-  }
-
-  @Override
-  public synchronized void resourceOffers(SchedulerDriver driver, List<Offer> offers) {
-    LOGGER.fine("Received offers " + offers.size());
-    reArrangeOffersBasedOnAffinity(offers);
-    int processedRequests = 0;
-    for (Offer offer : offers) {
-      if (requests.isEmpty() && !buildsInQueue(Jenkins.getInstance().getQueue())) {
-        unmatchedLabels.clear();
-        // Decline offer for a longer period if no slave is waiting to get spawned.
-        // This prevents unnecessarily getting offers every few seconds and causing
-        // starvation when running a lot of frameworks.
-        double rejectOfferDuration = mesosCloud.getDeclineOfferDurationDouble();
-        LOGGER.fine("No slave in queue. Rejecting offers for " + rejectOfferDuration + " ms");
-        Filters filters = Filters.newBuilder().setRefuseSeconds(rejectOfferDuration).build();
-        driver.declineOffer(offer.getId(), filters);
-        continue;
-      }
-
-      boolean taskCreated = false;
-
-      if (isOfferAvailable(offer)) {
-        for (Request request : requests) {
-          if (matches(offer, request)) {
-            LOGGER.fine("Offer matched! Creating mesos task " + request.request.slave.name);
-            try {
-              createMesosTask(offer, request);
-              unmatchedLabels.remove(request.request.slaveInfo.getLabelString());
-              taskCreated = true;
-              recentlyAcceptedOffers.put(offer.getSlaveId().getValue(), IGNORE);
-            } catch (Exception e) {
-              LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            }
-            requests.remove(request);
-            processedRequests++;
-            break;
-          }
-        }
-      }
-
-      if (!taskCreated) {
-        driver.declineOffer(offer.getId());
-      }
-    }
-    if (processedRequests > 0) {
-      if (!requests.isEmpty()) {
-        LOGGER.info("Created " + processedRequests + " tasks from " + offers.size() + " offers (" + requests.size() + " pending requests).");
-      } else {
-        LOGGER.info("Created " + processedRequests + " tasks from " + offers.size() + " offers.");
-      }
-    } else {
-      if (!requests.isEmpty()) {
-        LOGGER.info("Did not match any of the " + offers.size() + " offers (" + requests.size() + " pending requests)");
-      }
-    }
-    for (Request request: requests) {
-      unmatchedLabels.add(request.request.slaveInfo.getLabelString());
-    }
-  }
-
-  /**
-   * Determines whether an offer of a Mesos Agent has an unavailability set and is currently scheduled for maintenance.
-   * <br /><br />
-   * For information on how to use this feature with Mesos refer to
-   * <a href="http://mesos.apache.org/documentation/latest/maintenance/">Maintenance Primitives</a>)
-   *
-   * @param offer The offer to check for availability
-   * @return whether or not the offer is currently available
-   */
-  private boolean isOfferAvailable(Offer offer) {
-    if(offer.hasUnavailability()) {
-      Protos.Unavailability unavailability = offer.getUnavailability();
-
-      Date startTime = new Date(TimeUnit.NANOSECONDS.toMillis(unavailability.getStart().getNanoseconds()));
-      long duration = unavailability.getDuration().getNanoseconds();
-      Date endTime = new Date(startTime.getTime() + TimeUnit.NANOSECONDS.toMillis(duration));
-      Date currentTime = new Date();
-
-      return !(startTime.before(currentTime) && endTime.after(currentTime));
-    }
-
-    return true;
-  }
-
-  /**
-   * @return the unmatched labels during the last call of resourceOffers.
+    /**
+     * When created, we expect this scheduler to live for at least 1 minute before killing it.
+     * This prevents race conditions between threads provisioning new nodes and threads terminating them.
      */
-  public synchronized Set<String> getUnmatchedLabels() {
-    return Collections.unmodifiableSet(unmatchedLabels);
-  }
+    private static final Long MINIMUM_TIME_TO_LIVE = TimeUnit.MINUTES.toMillis(1);
 
-  /**
-   * Makes sure that it gives priority to recent mesos slaves
-   * (LRU algorithm) if its present in offers list.
-   * This will help in reducing build time since all the required
-   * artifacts will be present already.
-   * @param offers
-   */
-  private void reArrangeOffersBasedOnAffinity(List<Offer> offers) {
-    if(recentlyAcceptedOffers.size() > 0) {
-      //Iterates from least to most recently used.
-      OrderedMapIterator<String, Object> mapIterator = recentlyAcceptedOffers.mapIterator();
-      while (mapIterator.hasNext()) {
-        String recentSlaveId = mapIterator.next();
-        reArrangeOffersBasedOnAffinity(offers, recentSlaveId);
-      }
+    // We allocate 10% more memory to the Mesos task to account for the JVM overhead.
+    private static final double JVM_MEM_OVERHEAD_FACTOR = 0.1;
+
+    private static final String SLAVE_COMMAND_FORMAT =
+            "java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar ${MESOS_SANDBOX-.}/slave.jar %s %s -jnlpUrl %s";
+    private static final String JNLP_SECRET_FORMAT = "-secret %s";
+    public static final String PORT_RESOURCE_NAME = "ports";
+    public static final String MESOS_DEFAULT_ROLE = "*";
+    private final boolean multiThreaded;
+
+    private Queue<Request> requests;
+    private Set<String> unmatchedLabels;
+    private Map<TaskID, Result> results;
+    private Set<TaskID> finishedTasks;
+    private volatile SchedulerDriver driver;
+    private String jenkinsMaster;
+    private volatile MesosCloud mesosCloud;
+    private volatile boolean running;
+
+    private long startedTime;
+
+    private static final Logger LOGGER = Logger.getLogger(JenkinsScheduler.class.getName());
+
+    public static final Lock SUPERVISOR_LOCK = new ReentrantLock();
+
+    private static int lruCacheSize = Integer.getInteger(JenkinsScheduler.class.getName()+".lruCacheSize", 10);
+
+    private static LRUMap<String, Object> recentlyAcceptedOffers = new LRUMap<String, Object>(lruCacheSize);
+
+    private static final Object IGNORE = new Object();
+    private static final ExecutorService offersService = Executors.newSingleThreadExecutor();
+    private static final OfferQueue offerQueue = new OfferQueue();
+
+    public JenkinsScheduler(String jenkinsMaster, MesosCloud mesosCloud, boolean multiThreaded) {
+        startedTime = System.currentTimeMillis();
+        LOGGER.info("JenkinsScheduler instantiated with jenkins " + jenkinsMaster + " and mesos " + mesosCloud.getMaster());
+
+        this.jenkinsMaster = jenkinsMaster;
+        this.mesosCloud = mesosCloud;
+        this.multiThreaded = multiThreaded;
+
+        this.requests = new LinkedList<Request>();
+        this.unmatchedLabels = new HashSet<String>();
+        this.results = new HashMap<TaskID, Result>();
+        this.finishedTasks = Collections.newSetFromMap(new ConcurrentHashMap<TaskID, Boolean>());
+
+        if (multiThreaded) {
+            offersService.submit(new Runnable() {
+                @Override
+                public void run() {
+                    processOffers();
+                }
+            });
+        }
     }
-  }
 
-  private void reArrangeOffersBasedOnAffinity(List<Offer> offers, String recentSlaveId) {
-    int offerIndex = getOfferIndex(offers, recentSlaveId);
-    if(offerIndex > 0) {
-      LOGGER.fine("Rearranging offers based on affinity");
-      Offer recentOffer = offers.remove(offerIndex);
-      offers.add(0, recentOffer);
+    public synchronized void init() {
+        // This is to ensure that isRunning() returns true even when the driver is not yet inside run().
+        // This is important because MesosCloud.provision() starts a new framework whenever isRunning() is false.
+        running = true;
+        String targetUser = mesosCloud.getSlavesUser();
+        String webUrl = getJenkins().getRootUrl();
+        if (webUrl == null) webUrl = System.getenv("JENKINS_URL");
+        StandardUsernamePasswordCredentials credentials = mesosCloud.getCredentials();
+        String principal = credentials == null ? "jenkins" : credentials.getUsername();
+        String secret = credentials == null ? "" : Secret.toString(credentials.getPassword());
+        // Have Mesos fill in the current user.
+        FrameworkInfo framework = FrameworkInfo.newBuilder()
+                .setUser(targetUser == null ? "" : targetUser)
+                .setName(mesosCloud.getFrameworkName())
+                .setRole(mesosCloud.getRole())
+                .setPrincipal(principal)
+                .setCheckpoint(mesosCloud.isCheckpoint())
+                .setWebuiUrl(webUrl != null ? webUrl : "")
+                .build();
+
+        LOGGER.info("Initializing the Mesos driver with options"
+                + "\n" + "Framework Name: " + framework.getName()
+                + "\n" + "Principal: " + principal
+                + "\n" + "Checkpointing: " + framework.getCheckpoint()
+        );
+
+        if (StringUtils.isNotBlank(secret)) {
+
+            Credential credential = Credential.newBuilder()
+                    .setPrincipal(principal)
+                    .setSecret(secret)
+                    .build();
+
+            LOGGER.info("Authenticating with Mesos master with principal " + credential.getPrincipal());
+            driver = new MesosSchedulerDriver(JenkinsScheduler.this, framework, mesosCloud.getMaster(), credential);
+        } else {
+            driver = new MesosSchedulerDriver(JenkinsScheduler.this, framework, mesosCloud.getMaster());
+        }
+        // Start the framework.
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Status runStatus = driver.run();
+                    if (runStatus != Status.DRIVER_STOPPED) {
+                        LOGGER.severe("The Mesos driver was aborted! Status code: " + runStatus.getNumber());
+                    } else {
+                        LOGGER.info("The Mesos driver was stopped.");
+                    }
+                } catch(RuntimeException e) {
+                    LOGGER.log(Level.SEVERE, "Caught a RuntimeException", e);
+                } finally {
+                    SUPERVISOR_LOCK.lock();
+                    if (driver != null) {
+                        driver.abort();
+                    }
+                    driver = null;
+                    running = false;
+                    SUPERVISOR_LOCK.unlock();
+                }
+            }
+        }).start();
     }
-  }
 
-  private int getOfferIndex(List<Offer> offers, String recentSlaveId) {
-    int offerIndex = -1;
-    for (Offer offer : offers) {
-      if(offer.getSlaveId().getValue().equals(recentSlaveId)) {
-        offerIndex = offers.indexOf(offer);
+    public synchronized void stop() {
+        try {
+            SUPERVISOR_LOCK.lock();
+            if (driver != null) {
+                LOGGER.info("Stopping Mesos driver.");
+                driver.stop();
+            } else {
+                LOGGER.warning("Unable to stop Mesos driver:  driver is null.");
+            }
+            running = false;
+        } finally {
+            SUPERVISOR_LOCK.unlock();
+        }
+    }
+
+    public synchronized boolean isRunning() {
+        return running;
+    }
+
+    public synchronized void requestJenkinsSlave(Mesos.SlaveRequest request, Mesos.SlaveResult result) {
+        LOGGER.fine("Enqueuing jenkins slave request");
+        requests.add(new Request(request, result));
+        if (driver != null) {
+            // Ask mesos to send all offers, even the those we declined earlier.
+            // See comment in resourceOffers() for further details.
+            driver.reviveOffers();
+        }
+    }
+
+    public boolean reachedMinimumTimeToLive() {
+        return System.currentTimeMillis() - startedTime > MINIMUM_TIME_TO_LIVE;
+    }
+
+    /**
+     * @param slaveName the slave name in jenkins
+     * @return the jnlp url for the slave: http://[master]/computer/[slaveName]/slave-agent.jnlp
+     */
+    private String getJnlpUrl(String slaveName) {
+        return joinPaths(joinPaths(joinPaths(jenkinsMaster, "computer"), slaveName), "slave-agent.jnlp");
+    }
+
+    /**
+     * Slave needs to go through authentication while connecting through jnlp if security is enabled in jenkins.
+     * This method gets secret (for jnlp authentication) from jenkins, constructs command line argument and returns it.
+     *
+     * @param slaveName the slave name in jenkins
+     * @return jenkins slave secret corresponding to slave name in the format '-secret <secret>'
+     */
+    private String getJnlpSecret(String slaveName) {
+        String jnlpSecret = "";
+        if(getJenkins().isUseSecurity()) {
+            jnlpSecret = String.format(JNLP_SECRET_FORMAT, jenkins.slaves.JnlpSlaveAgentProtocol.SLAVE_SECRET.mac(slaveName));
+        }
+        return jnlpSecret;
+    }
+
+    private static String joinPaths(String prefix, String suffix) {
+        if (prefix.endsWith("/"))   prefix = prefix.substring(0, prefix.length()-1);
+        if (suffix.startsWith("/")) suffix = suffix.substring(1, suffix.length());
+
+        return prefix + '/' + suffix;
+    }
+
+    public synchronized void terminateJenkinsSlave(String name) {
+        LOGGER.info("Terminating jenkins slave " + name);
+
+        TaskID taskId = TaskID.newBuilder().setValue(name).build();
+
+        if (results.containsKey(taskId)) {
+            LOGGER.info("Killing mesos task " + taskId);
+            driver.killTask(taskId);
+        } else {
+            // This is handling the situation that a slave was provisioned but it never
+            // got scheduled because of resource scarcity and jenkins later tries to remove
+            // the offline slave but since it was not scheduled we have to remove it from
+            // the request queue. The method has been also synchronized because there is a race
+            // between this removal request from jenkins and a resource getting freed up in mesos
+            // resulting in scheduling the slave and resulting in orphaned task/slave not monitored
+            // by Jenkins.
+
+            for(Request request : requests) {
+                if(request.request.slave.name.equals(name)) {
+                    LOGGER.info("Removing enqueued mesos task " + name);
+                    requests.remove(request);
+                    // Also signal the Thread of the MesosComputerLauncher.launch() to exit from latch.await()
+                    // Otherwise the Thread will stay in WAIT forever -> Leak!
+                    request.result.failed(request.request.slave);
+                    return;
+                }
+            }
+
+            LOGGER.warning("Asked to kill unknown mesos task " + taskId);
+        }
+
+        // Since this task is now running, we should not start this task up again at a later point in time
+        finishedTasks.add(taskId);
+
+        if (mesosCloud.isOnDemandRegistration()) {
+            supervise();
+        }
+
+    }
+
+    @Override
+    public void registered(SchedulerDriver driver, FrameworkID frameworkId, MasterInfo masterInfo) {
+        LOGGER.info("Framework registered! ID = " + frameworkId.getValue());
+    }
+
+    @Override
+    public void reregistered(SchedulerDriver driver, MasterInfo masterInfo) {
+        LOGGER.info("Framework re-registered");
+    }
+
+    @Override
+    public void disconnected(SchedulerDriver driver) {
+        LOGGER.info("Framework disconnected!");
+    }
+
+    private void declineOffer(Offer offer, double duration) {
+        LOGGER.fine("Rejecting offer " + offer.getId().getValue() + " for " + duration + " seconds");
+        Filters filters = Filters.newBuilder().setRefuseSeconds(duration).build();
+        driver.declineOffer(offer.getId(), filters);
+    }
+
+    @VisibleForTesting
+    void processOffers() {
+        List<Offer> offers = offerQueue.takeAll();
+        LOGGER.fine("Received offers " + offers.size());
+        reArrangeOffersBasedOnAffinity(offers);
+        int processedRequests = 0;
+        for (Offer offer : offers) {
+            if (requests.isEmpty() && !buildsInQueue(Jenkins.getInstance().getQueue())) {
+                unmatchedLabels.clear();
+                // Decline offer for a longer period if no slave is waiting to get spawned.
+                // This prevents unnecessarily getting offers every few seconds and causing
+                // starvation when running a lot of frameworks.
+                LOGGER.fine("No slave in queue.");
+                declineOffer(offer, mesosCloud.getDeclineOfferDurationDouble());
+                continue;
+            }
+
+            boolean taskCreated = false;
+
+            if (isOfferAvailable(offer)) {
+                for (Request request : requests) {
+                    if (matches(offer, request)) {
+                        LOGGER.fine("Offer matched! Creating mesos task " + request.request.slave.name);
+                        try {
+                            createMesosTask(offer, request);
+                            unmatchedLabels.remove(request.request.slaveInfo.getLabelString());
+                            taskCreated = true;
+                            recentlyAcceptedOffers.put(offer.getSlaveId().getValue(), IGNORE);
+                        } catch (Exception e) {
+                            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                        }
+                        requests.remove(request);
+                        processedRequests++;
+                        break;
+                    }
+                }
+            }
+
+            if (!taskCreated) {
+                driver.declineOffer(offer.getId());
+            }
+        }
+        if (processedRequests > 0) {
+            if (!requests.isEmpty()) {
+                LOGGER.info("Created " + processedRequests + " tasks from " + offers.size() + " offers (" + requests.size() + " pending requests).");
+            } else {
+                LOGGER.info("Created " + processedRequests + " tasks from " + offers.size() + " offers.");
+            }
+        } else {
+            if (!requests.isEmpty()) {
+                LOGGER.info("Did not match any of the " + offers.size() + " offers (" + requests.size() + " pending requests)");
+            }
+        }
+        for (Request request: requests) {
+            unmatchedLabels.add(request.request.slaveInfo.getLabelString());
+        }
+    }
+
+    @Override
+    public synchronized void resourceOffers(SchedulerDriver driver, List<Offer> offers) {
+        for (Protos.Offer offer : offers) {
+            boolean queued = offerQueue.offer(offer);
+            if (!queued) {
+                LOGGER.warning("Offer queue is full.");
+                declineOffer(offer, MesosCloud.SHORT_DECLINE_OFFER_DURATION_SEC);
+            }
+        }
+
+        if (!multiThreaded) {
+            processOffers();
+        }
+    }
+
+    /**
+     * Determines whether an offer of a Mesos Agent has an unavailability set and is currently scheduled for maintenance.
+     * <br /><br />
+     * For information on how to use this feature with Mesos refer to
+     * <a href="http://mesos.apache.org/documentation/latest/maintenance/">Maintenance Primitives</a>)
+     *
+     * @param offer The offer to check for availability
+     * @return whether or not the offer is currently available
+     */
+    private boolean isOfferAvailable(Offer offer) {
+        if(offer.hasUnavailability()) {
+            Protos.Unavailability unavailability = offer.getUnavailability();
+
+            Date startTime = new Date(TimeUnit.NANOSECONDS.toMillis(unavailability.getStart().getNanoseconds()));
+            long duration = unavailability.getDuration().getNanoseconds();
+            Date endTime = new Date(startTime.getTime() + TimeUnit.NANOSECONDS.toMillis(duration));
+            Date currentTime = new Date();
+
+            return !(startTime.before(currentTime) && endTime.after(currentTime));
+        }
+
+        return true;
+    }
+
+    /**
+     * @return the unmatched labels during the last call of resourceOffers.
+     */
+    public synchronized Set<String> getUnmatchedLabels() {
+        return Collections.unmodifiableSet(unmatchedLabels);
+    }
+
+    /**
+     * Makes sure that it gives priority to recent mesos slaves
+     * (LRU algorithm) if its present in offers list.
+     * This will help in reducing build time since all the required
+     * artifacts will be present already.
+     * @param offers
+     */
+    private void reArrangeOffersBasedOnAffinity(List<Offer> offers) {
+        if(recentlyAcceptedOffers.size() > 0) {
+            //Iterates from least to most recently used.
+            OrderedMapIterator<String, Object> mapIterator = recentlyAcceptedOffers.mapIterator();
+            while (mapIterator.hasNext()) {
+                String recentSlaveId = mapIterator.next();
+                reArrangeOffersBasedOnAffinity(offers, recentSlaveId);
+            }
+        }
+    }
+
+    private void reArrangeOffersBasedOnAffinity(List<Offer> offers, String recentSlaveId) {
+        int offerIndex = getOfferIndex(offers, recentSlaveId);
+        if(offerIndex > 0) {
+            LOGGER.fine("Rearranging offers based on affinity");
+            Offer recentOffer = offers.remove(offerIndex);
+            offers.add(0, recentOffer);
+        }
+    }
+
+    private int getOfferIndex(List<Offer> offers, String recentSlaveId) {
+        int offerIndex = -1;
+        for (Offer offer : offers) {
+            if(offer.getSlaveId().getValue().equals(recentSlaveId)) {
+                offerIndex = offers.indexOf(offer);
+                return offerIndex;
+            }
+        }
         return offerIndex;
-      }
     }
-    return offerIndex;
-  }
 
-  private boolean matches(Offer offer, Request request) {
-    double cpus = -1;
-    double mem = -1;
-    List<Range> ports = null;
+    private boolean matches(Offer offer, Request request) {
+        double cpus = -1;
+        double mem = -1;
+        List<Range> ports = null;
 
-    for (Resource resource : offer.getResourcesList()) {
-      String resourceRole = resource.getRole();
-      String expectedRole = mesosCloud.getRole();
-      if (! (resourceRole.equals(expectedRole) || resourceRole.equals("*"))) {
-        LOGGER.warning("Resource role " + resourceRole +
-            " doesn't match expected role " + expectedRole);
-        continue;
-      }
-      if (resource.getName().equals("cpus")) {
-        if (resource.getType().equals(Value.Type.SCALAR)) {
-          cpus = resource.getScalar().getValue();
+        for (Resource resource : offer.getResourcesList()) {
+            String resourceRole = resource.getRole();
+            String expectedRole = mesosCloud.getRole();
+            if (! (resourceRole.equals(expectedRole) || resourceRole.equals("*"))) {
+                LOGGER.warning("Resource role " + resourceRole +
+                        " doesn't match expected role " + expectedRole);
+                continue;
+            }
+            if (resource.getName().equals("cpus")) {
+                if (resource.getType().equals(Value.Type.SCALAR)) {
+                    cpus = resource.getScalar().getValue();
+                } else {
+                    LOGGER.severe("Cpus resource was not a scalar: " + resource.getType().toString());
+                }
+            } else if (resource.getName().equals("mem")) {
+                if (resource.getType().equals(Value.Type.SCALAR)) {
+                    mem = resource.getScalar().getValue();
+                } else {
+                    LOGGER.severe("Mem resource was not a scalar: " + resource.getType().toString());
+                }
+            } else if (resource.getName().equals("disk")) {
+                LOGGER.fine("Ignoring disk resources from offer");
+            } else if (resource.getName().equals("ports")) {
+                if (resource.getType().equals(Value.Type.RANGES)) {
+                    ports = resource.getRanges().getRangeList();
+                } else {
+                    LOGGER.severe("Ports resource was not a range: " + resource.getType().toString());
+                }
+            } else {
+                LOGGER.warning("Ignoring unknown resource type: " + resource.getName());
+            }
+        }
+
+        if (cpus < 0) LOGGER.fine("No cpus resource present");
+        if (mem < 0)  LOGGER.fine("No mem resource present");
+
+        MesosSlaveInfo.ContainerInfo containerInfo = request.request.slaveInfo.getContainerInfo();
+
+        boolean hasPortMappings = containerInfo != null ? containerInfo.hasPortMappings() : false;
+
+        boolean hasPortResources = ports != null && !ports.isEmpty();
+
+        if (hasPortMappings && !hasPortResources) {
+            LOGGER.severe("No ports resource present");
+        }
+
+        // Check for sufficient cpu and memory resources in the offer.
+        double requestedCpus = request.request.cpus;
+        double requestedMem = (1 + JVM_MEM_OVERHEAD_FACTOR) * request.request.mem;
+        // Get matching slave attribute for this label.
+        JSONObject slaveAttributes = getMesosCloud().getSlaveAttributeForLabel(request.request.slaveInfo.getLabelString());
+
+        if (requestedCpus <= cpus
+                && requestedMem <= mem
+                && !(hasPortMappings && !hasPortResources)
+                && slaveAttributesMatch(offer, slaveAttributes)) {
+            return true;
         } else {
-          LOGGER.severe("Cpus resource was not a scalar: " + resource.getType().toString());
+            String requestedPorts = containerInfo != null
+                    ? StringUtils.join(containerInfo.getPortMappings().toArray(), "/")
+                    : "";
+
+            LOGGER.fine(
+                    "Offer not sufficient for slave request:\n" +
+                            offer.getResourcesList().toString() +
+                            "\n" + offer.getAttributesList().toString() +
+                            "\nRequested for Jenkins slave:\n" +
+                            "  cpus:  " + requestedCpus + "\n" +
+                            "  mem:   " + requestedMem + "\n" +
+                            "  ports: " + requestedPorts + "\n" +
+                            "  attributes:  " + (slaveAttributes == null ? ""  : slaveAttributes.toString()));
+            return false;
         }
-      } else if (resource.getName().equals("mem")) {
-        if (resource.getType().equals(Value.Type.SCALAR)) {
-          mem = resource.getScalar().getValue();
-        } else {
-          LOGGER.severe("Mem resource was not a scalar: " + resource.getType().toString());
-        }
-      } else if (resource.getName().equals("disk")) {
-        LOGGER.fine("Ignoring disk resources from offer");
-      } else if (resource.getName().equals("ports")) {
-        if (resource.getType().equals(Value.Type.RANGES)) {
-          ports = resource.getRanges().getRangeList();
-        } else {
-          LOGGER.severe("Ports resource was not a range: " + resource.getType().toString());
-        }
-      } else {
-        LOGGER.warning("Ignoring unknown resource type: " + resource.getName());
-      }
     }
 
-    if (cpus < 0) LOGGER.fine("No cpus resource present");
-    if (mem < 0)  LOGGER.fine("No mem resource present");
-
-    MesosSlaveInfo.ContainerInfo containerInfo = request.request.slaveInfo.getContainerInfo();
-
-    boolean hasPortMappings = containerInfo != null ? containerInfo.hasPortMappings() : false;
-
-    boolean hasPortResources = ports != null && !ports.isEmpty();
-
-    if (hasPortMappings && !hasPortResources) {
-      LOGGER.severe("No ports resource present");
+    private boolean buildsInQueue(hudson.model.Queue queue) {
+        hudson.model.Queue.Item[] items =  queue.getItems();
+        if(items != null) {
+            for(hudson.model.Queue.Item item: items) {
+                // Check and return if there is an item in jenkins queue for which this MesosCloud can provsion a slave
+                if(mesosCloud.canProvision(item.getAssignedLabel())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
-    // Check for sufficient cpu and memory resources in the offer.
-    double requestedCpus = request.request.cpus;
-    double requestedMem = (1 + JVM_MEM_OVERHEAD_FACTOR) * request.request.mem;
-    // Get matching slave attribute for this label.
-    JSONObject slaveAttributes = getMesosCloud().getSlaveAttributeForLabel(request.request.slaveInfo.getLabelString());
+    /**
+     * Checks whether the cloud Mesos slave attributes match those from the Mesos offer.
+     *
+     * @param offer Mesos offer data object.
+     * @return true if all the offer attributes match and false if not.
+     */
+    private boolean slaveAttributesMatch(Offer offer, JSONObject slaveAttributes) {
 
-    if (requestedCpus <= cpus
-            && requestedMem <= mem
-            && !(hasPortMappings && !hasPortResources)
-            && slaveAttributesMatch(offer, slaveAttributes)) {
-      return true;
-    } else {
-      String requestedPorts = containerInfo != null
-              ? StringUtils.join(containerInfo.getPortMappings().toArray(), "/")
-              : "";
+        //Accept any and all Mesos slave offers by default.
+        boolean slaveTypeMatch = true;
 
-      LOGGER.fine(
-          "Offer not sufficient for slave request:\n" +
-          offer.getResourcesList().toString() +
-          "\n" + offer.getAttributesList().toString() +
-          "\nRequested for Jenkins slave:\n" +
-          "  cpus:  " + requestedCpus + "\n" +
-          "  mem:   " + requestedMem + "\n" +
-          "  ports: " + requestedPorts + "\n" +
-          "  attributes:  " + (slaveAttributes == null ? ""  : slaveAttributes.toString()));
-      return false;
-    }
-  }
+        //Collect the list of attributes from the offer as key-value pairs
+        Map<String, String> attributesMap = new HashMap<String, String>();
+        for (Attribute attribute : offer.getAttributesList()) {
+            attributesMap.put(attribute.getName(), attribute.getText().getValue());
+        }
 
-  private boolean buildsInQueue(hudson.model.Queue queue) {
-   hudson.model.Queue.Item[] items =  queue.getItems();
-   if(items != null) {
-     for(hudson.model.Queue.Item item: items) {
-       // Check and return if there is an item in jenkins queue for which this MesosCloud can provsion a slave
-       if(mesosCloud.canProvision(item.getAssignedLabel())) {
-         return true;
-       }
-     }
-   }
-    return false;
-  }
+        if (slaveAttributes != null && slaveAttributes.size() > 0) {
 
-  /**
-  * Checks whether the cloud Mesos slave attributes match those from the Mesos offer.
-  *
-  * @param offer Mesos offer data object.
-  * @return true if all the offer attributes match and false if not.
-  */
-  private boolean slaveAttributesMatch(Offer offer, JSONObject slaveAttributes) {
+            //Iterate over the cloud attributes to see if they exist in the offer attributes list.
+            Iterator iterator = slaveAttributes.keys();
+            while (iterator.hasNext()) {
 
-    //Accept any and all Mesos slave offers by default.
-    boolean slaveTypeMatch = true;
+                String key = (String) iterator.next();
 
-    //Collect the list of attributes from the offer as key-value pairs
-    Map<String, String> attributesMap = new HashMap<String, String>();
-    for (Attribute attribute : offer.getAttributesList()) {
-      attributesMap.put(attribute.getName(), attribute.getText().getValue());
+                //If there is a single absent attribute then we should reject this offer.
+                if (!(attributesMap.containsKey(key) && attributesMap.get(key).toString().equals(slaveAttributes.getString(key)))) {
+                    slaveTypeMatch = false;
+                    break;
+                }
+            }
+        }
+
+        return slaveTypeMatch;
     }
 
-    if (slaveAttributes != null && slaveAttributes.size() > 0) {
-
-      //Iterate over the cloud attributes to see if they exist in the offer attributes list.
-      Iterator iterator = slaveAttributes.keys();
-      while (iterator.hasNext()) {
-
-        String key = (String) iterator.next();
-
-        //If there is a single absent attribute then we should reject this offer.
-        if (!(attributesMap.containsKey(key) && attributesMap.get(key).toString().equals(slaveAttributes.getString(key)))) {
-          slaveTypeMatch = false;
-          break;
-        }
-      }
+    @VisibleForTesting
+    void setDriver(SchedulerDriver driver) {
+        this.driver = driver;
     }
 
-    return slaveTypeMatch;
-  }
+    @VisibleForTesting
+    String findRoleForPorts(Offer offer) {
 
-  @VisibleForTesting
-  void setDriver(SchedulerDriver driver) {
-    this.driver = driver;
-  }
+        String role = MESOS_DEFAULT_ROLE;
+        // Locate the port resource in the offer
+        for (Resource resource : offer.getResourcesList()) {
+            if (resource.getName().equals(PORT_RESOURCE_NAME)) {
+                role = resource.getRole();
 
-  @VisibleForTesting
-  String findRoleForPorts(Offer offer) {
-
-      String role = MESOS_DEFAULT_ROLE;
-      // Locate the port resource in the offer
-      for (Resource resource : offer.getResourcesList()) {
-        if (resource.getName().equals(PORT_RESOURCE_NAME)) {
-            role = resource.getRole();
-
+            }
         }
-      }
-      return role;
-  }
+        return role;
+    }
 
-  @VisibleForTesting
-  SortedSet<Long> findPortsToUse(Offer offer, int maxCount) {
-      SortedSet<Long> portsToUse = new TreeSet<Long>();
-      List<Value.Range> portRangesList = null;
+    @VisibleForTesting
+    SortedSet<Long> findPortsToUse(Offer offer, int maxCount) {
+        SortedSet<Long> portsToUse = new TreeSet<Long>();
+        List<Value.Range> portRangesList = null;
 
-      // Locate the port resource in the offer
-      for (Resource resource : offer.getResourcesList()) {
-        if (resource.getName().equals(PORT_RESOURCE_NAME)) {
-          portRangesList = resource.getRanges().getRangeList();
-          break;
+        // Locate the port resource in the offer
+        for (Resource resource : offer.getResourcesList()) {
+            if (resource.getName().equals(PORT_RESOURCE_NAME)) {
+                portRangesList = resource.getRanges().getRangeList();
+                break;
+            }
         }
-      }
 
-      LOGGER.fine("portRangesList=" + portRangesList);
+        LOGGER.fine("portRangesList=" + portRangesList);
 
-      /**
-       * We need to find maxCount ports to use.
-       * We are provided a list of port ranges to use
-       * We are assured by the offer check that we have enough ports to use
-       */
-      // Check this port range for ports that we can use
-      if (portRangesList != null) {
-        for (Value.Range currentPortRange : portRangesList) {
-          // Check each port until we reach the end of the current range
-          long begin = currentPortRange.getBegin();
-          long end = currentPortRange.getEnd();
-          for (long candidatePort = begin; candidatePort <= end && portsToUse.size() < maxCount; candidatePort++) {
-            portsToUse.add(candidatePort);
-          }
+        /**
+         * We need to find maxCount ports to use.
+         * We are provided a list of port ranges to use
+         * We are assured by the offer check that we have enough ports to use
+         */
+        // Check this port range for ports that we can use
+        if (portRangesList != null) {
+            for (Value.Range currentPortRange : portRangesList) {
+                // Check each port until we reach the end of the current range
+                long begin = currentPortRange.getBegin();
+                long end = currentPortRange.getEnd();
+                for (long candidatePort = begin; candidatePort <= end && portsToUse.size() < maxCount; candidatePort++) {
+                    portsToUse.add(candidatePort);
+                }
+            }
         }
-      }
 
-      return portsToUse;
-  }
+        return portsToUse;
+    }
 
-  private void createMesosTask(Offer offer, Request request) {
-    final String slaveName = request.request.slave.name;
-    TaskID taskId = TaskID.newBuilder().setValue(slaveName).build();
+    private void createMesosTask(Offer offer, Request request) {
+        final String slaveName = request.request.slave.name;
+        TaskID taskId = TaskID.newBuilder().setValue(slaveName).build();
 
-    LOGGER.fine("Launching task " + taskId.getValue() + " with URI " +
+        LOGGER.fine("Launching task " + taskId.getValue() + " with URI " +
                 joinPaths(jenkinsMaster, SLAVE_JAR_URI_SUFFIX));
 
-    if (isExistingTask(taskId)) {
-        refuseOffer(offer);
-        return;
-    }
-
-    Jenkins jenkins = getJenkins();
-    for (final Computer computer : jenkins.getComputers()) {
-        if (!MesosComputer.class.isInstance(computer)) {
-            LOGGER.finer("Not a mesos computer, skipping");
-            continue;
+        if (isExistingTask(taskId)) {
+            refuseOffer(offer);
+            return;
         }
 
-        MesosComputer mesosComputer = (MesosComputer) computer;
-        MesosSlave mesosSlave = mesosComputer.getNode();
-
-        if (taskId.getValue().equals(computer.getName()) && mesosSlave.isPendingDelete()) {
-            LOGGER.info("This mesos task " + taskId.getValue() + " is pending deletion. Not launching another task");
-            driver.declineOffer(offer.getId());
-        }
-    }
-
-    CommandInfo.Builder commandBuilder = getCommandInfoBuilder(request);
-    TaskInfo.Builder taskBuilder = getTaskInfoBuilder(offer, request, taskId, commandBuilder);
-
-    if (request.request.slaveInfo.getContainerInfo() != null) {
-        getContainerInfoBuilder(offer, request, slaveName, taskBuilder);
-    }
-
-    List<TaskInfo> tasks = new ArrayList<TaskInfo>();
-    tasks.add(taskBuilder.build());
-    Filters filters = Filters.newBuilder().setRefuseSeconds(1).build();
-    driver.launchTasks(offer.getId(), tasks, filters);
-
-    results.put(taskId, new Result(request.result, new Mesos.JenkinsSlave(offer.getSlaveId()
-        .getValue())));
-    finishedTasks.add(taskId);
-  }
-
-  @NonNull
-  private static Jenkins getJenkins() {
-    Jenkins jenkins = Jenkins.getInstance();
-    if (jenkins == null) {
-      throw new IllegalStateException("Jenkins is null");
-    }
-    return jenkins;
-  }
-
-  private void detectAndAddAdditionalURIs(Request request, CommandInfo.Builder commandBuilder) {
-
-    if (request.request.slaveInfo.getAdditionalURIs() != null) {
-      for (MesosSlaveInfo.URI uri : request.request.slaveInfo.getAdditionalURIs()) {
-        commandBuilder.addUris(
-            CommandInfo.URI.newBuilder().setValue(
-                uri.getValue()).setExecutable(uri.isExecutable()).setExtract(uri.isExtract()));
-      }
-    }
-  }
-
-  private TaskInfo.Builder getTaskInfoBuilder(Offer offer, Request request, TaskID taskId, CommandInfo.Builder commandBuilder) {
-    TaskInfo.Builder builder = TaskInfo.newBuilder()
-        .setName("task " + taskId.getValue())
-        .setTaskId(taskId)
-        .setSlaveId(offer.getSlaveId())
-        .setCommand(commandBuilder.build());
-
-    double cpusNeeded = request.request.cpus;
-    double memNeeded = (1 + JVM_MEM_OVERHEAD_FACTOR) * request.request.mem;
-    double diskNeeded = request.request.diskNeeded;
-
-    for (Resource r : offer.getResourcesList()) {
-      if (r.getName().equals("cpus") && cpusNeeded > 0) {
-        double cpus = Math.min(r.getScalar().getValue(), cpusNeeded);
-        builder.addResources(
-            Resource
-                .newBuilder()
-                .setName("cpus")
-                .setType(Value.Type.SCALAR)
-                .setRole(r.getRole())
-                .setScalar(
-                    Value.Scalar.newBuilder()
-                        .setValue(cpus).build()).build());
-        cpusNeeded -= cpus;
-      } else if (r.getName().equals("mem") && memNeeded > 0) {
-        double mem = Math.min(r.getScalar().getValue(), memNeeded);
-        builder.addResources(
-            Resource
-                .newBuilder()
-                .setName("mem")
-                .setType(Value.Type.SCALAR)
-                .setRole(r.getRole())
-                .setScalar(
-                    Value.Scalar.newBuilder()
-                        .setValue(mem).build()).build());
-        memNeeded -= mem;
-      } else if (r.getName().equals("disk") && diskNeeded > 0) {
-        double disk = Math.min(r.getScalar().getValue(), diskNeeded);
-        builder.addResources(
-            Resource
-                .newBuilder()
-                .setName("disk")
-                .setType(Value.Type.SCALAR)
-                .setRole(r.getRole())
-                .setScalar(
-                        Value.Scalar.newBuilder()
-                        .setValue(disk).build()).build());
-
-      }
-      else if (cpusNeeded == 0 && memNeeded == 0 && diskNeeded == 0) {
-        break;
-      }
-    }
-    return builder;
-  }
-
-  private void getContainerInfoBuilder(Offer offer, Request request, String slaveName, TaskInfo.Builder taskBuilder) {
-      MesosSlaveInfo.ContainerInfo containerInfo = request.request.slaveInfo.getContainerInfo();
-      ContainerInfo.Type containerType = ContainerInfo.Type.valueOf(containerInfo.getType());
-
-      ContainerInfo.Builder containerInfoBuilder = ContainerInfo.newBuilder() //
-              .setType(containerType); //
-
-      switch(containerType) {
-        case DOCKER:
-          LOGGER.info("Launching in Docker Mode:" + containerInfo.getDockerImage());
-          DockerInfo.Builder dockerInfoBuilder = DockerInfo.newBuilder() //
-              .setImage(containerInfo.getDockerImage())
-              .setPrivileged(containerInfo.getDockerPrivilegedMode())
-              .setForcePullImage(containerInfo.getDockerForcePullImage());
-
-          if (containerInfo.getParameters() != null) {
-            for (MesosSlaveInfo.Parameter parameter : containerInfo.getParameters()) {
-              LOGGER.info("Adding Docker parameter '" + parameter.getKey() + ":" + parameter.getValue() + "'");
-              dockerInfoBuilder.addParameters(Parameter.newBuilder().setKey(parameter.getKey()).setValue(parameter.getValue()).build());
+        Jenkins jenkins = getJenkins();
+        for (final Computer computer : jenkins.getComputers()) {
+            if (!MesosComputer.class.isInstance(computer)) {
+                LOGGER.finer("Not a mesos computer, skipping");
+                continue;
             }
-          }
 
-          String networking = request.request.slaveInfo.getContainerInfo().getNetworking();
-          dockerInfoBuilder.setNetwork(Network.valueOf(networking));
+            MesosComputer mesosComputer = (MesosComputer) computer;
+            MesosSlave mesosSlave = mesosComputer.getNode();
 
-          //  https://github.com/jenkinsci/mesos-plugin/issues/109
-          if (dockerInfoBuilder.getNetwork() != Network.HOST) {
-              containerInfoBuilder.setHostname(slaveName);
-          }
-
-          if (request.request.slaveInfo.getContainerInfo().hasPortMappings()) {
-              List<MesosSlaveInfo.PortMapping> portMappings = request.request.slaveInfo.getContainerInfo().getPortMappings();
-              Set<Long> portsToUse = findPortsToUse(offer, portMappings.size());
-              String roleToUse = findRoleForPorts(offer);
-              Iterator<Long> iterator = portsToUse.iterator();
-              Value.Ranges.Builder portRangesBuilder = Value.Ranges.newBuilder();
-
-              for (MesosSlaveInfo.PortMapping portMapping : portMappings) {
-                  PortMapping.Builder portMappingBuilder = PortMapping.newBuilder() //
-                          .setContainerPort(portMapping.getContainerPort()) //
-                          .setProtocol(portMapping.getProtocol());
-
-                  Long portToUse = portMapping.getHostPort() == null ? iterator.next() : portMapping.getHostPort();
-
-                  portMappingBuilder.setHostPort(portToUse.intValue());
-
-                  portRangesBuilder.addRange(
-                    Value.Range
-                      .newBuilder()
-                      .setBegin(portToUse)
-                      .setEnd(portToUse)
-                  );
-
-                  LOGGER.finest("Adding portMapping: " + portMapping);
-                  dockerInfoBuilder.addPortMappings(portMappingBuilder);
-              }
-
-              taskBuilder.addResources(
-                Resource
-                  .newBuilder()
-                  .setName("ports")
-                  .setType(Value.Type.RANGES)
-                  .setRole(roleToUse)
-                  .setRanges(portRangesBuilder)
-                  );
-          } else {
-              LOGGER.fine("No portMappings found");
-          }
-
-          containerInfoBuilder.setDocker(dockerInfoBuilder);
-          break;
-        default:
-          LOGGER.warning("Unknown container type:" + containerInfo.getType());
-      }
-
-      if (containerInfo.getVolumes() != null) {
-        for (MesosSlaveInfo.Volume volume : containerInfo.getVolumes()) {
-          LOGGER.info("Adding volume '" + volume.getContainerPath() + "'");
-          Volume.Builder volumeBuilder = Volume.newBuilder()
-              .setContainerPath(volume.getContainerPath())
-              .setMode(volume.isReadOnly() ? Mode.RO : Mode.RW);
-          if (!volume.getHostPath().isEmpty()) {
-            volumeBuilder.setHostPath(volume.getHostPath());
-          }
-          containerInfoBuilder.addVolumes(volumeBuilder.build());
+            if (taskId.getValue().equals(computer.getName()) && mesosSlave.isPendingDelete()) {
+                LOGGER.info("This mesos task " + taskId.getValue() + " is pending deletion. Not launching another task");
+                driver.declineOffer(offer.getId());
+            }
         }
-      }
 
-      if (containerInfo.hasNetworkInfos()) {
-        for (MesosSlaveInfo.NetworkInfo networkInfo : containerInfo.getNetworkInfos()) {
+        CommandInfo.Builder commandBuilder = getCommandInfoBuilder(request);
+        TaskInfo.Builder taskBuilder = getTaskInfoBuilder(offer, request, taskId, commandBuilder);
 
-          NetworkInfo.Builder networkInfoBuilder = NetworkInfo.newBuilder();
-
-          if (networkInfo.hasNetworkName()) {
-            //Add the virtual network specified, trimming edges for whitespace
-            networkInfoBuilder.setName(networkInfo.getNetworkName().trim());
-            LOGGER.info("Launching container on network " + networkInfo.getNetworkName() );
-          }
-
-          containerInfoBuilder.addNetworkInfos(networkInfoBuilder.build());
+        if (request.request.slaveInfo.getContainerInfo() != null) {
+            getContainerInfoBuilder(offer, request, slaveName, taskBuilder);
         }
-      }
 
-      taskBuilder.setContainer(containerInfoBuilder.build());
+        List<TaskInfo> tasks = new ArrayList<TaskInfo>();
+        tasks.add(taskBuilder.build());
+        Filters filters = Filters.newBuilder().setRefuseSeconds(1).build();
+        driver.launchTasks(offer.getId(), tasks, filters);
+
+        results.put(taskId, new Result(request.result, new Mesos.JenkinsSlave(offer.getSlaveId()
+                .getValue())));
+        finishedTasks.add(taskId);
     }
 
-  @VisibleForTesting
-  CommandInfo.Builder getCommandInfoBuilder(Request request) {
+    @NonNull
+    private static Jenkins getJenkins() {
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            throw new IllegalStateException("Jenkins is null");
+        }
+        return jenkins;
+    }
+
+    private void detectAndAddAdditionalURIs(Request request, CommandInfo.Builder commandBuilder) {
+
+        if (request.request.slaveInfo.getAdditionalURIs() != null) {
+            for (MesosSlaveInfo.URI uri : request.request.slaveInfo.getAdditionalURIs()) {
+                commandBuilder.addUris(
+                        CommandInfo.URI.newBuilder().setValue(
+                                uri.getValue()).setExecutable(uri.isExecutable()).setExtract(uri.isExtract()));
+            }
+        }
+    }
+
+    private TaskInfo.Builder getTaskInfoBuilder(Offer offer, Request request, TaskID taskId, CommandInfo.Builder commandBuilder) {
+        TaskInfo.Builder builder = TaskInfo.newBuilder()
+                .setName("task " + taskId.getValue())
+                .setTaskId(taskId)
+                .setSlaveId(offer.getSlaveId())
+                .setCommand(commandBuilder.build());
+
+        double cpusNeeded = request.request.cpus;
+        double memNeeded = (1 + JVM_MEM_OVERHEAD_FACTOR) * request.request.mem;
+        double diskNeeded = request.request.diskNeeded;
+
+        for (Resource r : offer.getResourcesList()) {
+            if (r.getName().equals("cpus") && cpusNeeded > 0) {
+                double cpus = Math.min(r.getScalar().getValue(), cpusNeeded);
+                builder.addResources(
+                        Resource
+                                .newBuilder()
+                                .setName("cpus")
+                                .setType(Value.Type.SCALAR)
+                                .setRole(r.getRole())
+                                .setScalar(
+                                        Value.Scalar.newBuilder()
+                                                .setValue(cpus).build()).build());
+                cpusNeeded -= cpus;
+            } else if (r.getName().equals("mem") && memNeeded > 0) {
+                double mem = Math.min(r.getScalar().getValue(), memNeeded);
+                builder.addResources(
+                        Resource
+                                .newBuilder()
+                                .setName("mem")
+                                .setType(Value.Type.SCALAR)
+                                .setRole(r.getRole())
+                                .setScalar(
+                                        Value.Scalar.newBuilder()
+                                                .setValue(mem).build()).build());
+                memNeeded -= mem;
+            } else if (r.getName().equals("disk") && diskNeeded > 0) {
+                double disk = Math.min(r.getScalar().getValue(), diskNeeded);
+                builder.addResources(
+                        Resource
+                                .newBuilder()
+                                .setName("disk")
+                                .setType(Value.Type.SCALAR)
+                                .setRole(r.getRole())
+                                .setScalar(
+                                        Value.Scalar.newBuilder()
+                                                .setValue(disk).build()).build());
+
+            }
+            else if (cpusNeeded == 0 && memNeeded == 0 && diskNeeded == 0) {
+                break;
+            }
+        }
+        return builder;
+    }
+
+    private void getContainerInfoBuilder(Offer offer, Request request, String slaveName, TaskInfo.Builder taskBuilder) {
+        MesosSlaveInfo.ContainerInfo containerInfo = request.request.slaveInfo.getContainerInfo();
+        ContainerInfo.Type containerType = ContainerInfo.Type.valueOf(containerInfo.getType());
+
+        ContainerInfo.Builder containerInfoBuilder = ContainerInfo.newBuilder() //
+                .setType(containerType); //
+
+        switch(containerType) {
+            case DOCKER:
+                LOGGER.info("Launching in Docker Mode:" + containerInfo.getDockerImage());
+                DockerInfo.Builder dockerInfoBuilder = DockerInfo.newBuilder() //
+                        .setImage(containerInfo.getDockerImage())
+                        .setPrivileged(containerInfo.getDockerPrivilegedMode())
+                        .setForcePullImage(containerInfo.getDockerForcePullImage());
+
+                if (containerInfo.getParameters() != null) {
+                    for (MesosSlaveInfo.Parameter parameter : containerInfo.getParameters()) {
+                        LOGGER.info("Adding Docker parameter '" + parameter.getKey() + ":" + parameter.getValue() + "'");
+                        dockerInfoBuilder.addParameters(Parameter.newBuilder().setKey(parameter.getKey()).setValue(parameter.getValue()).build());
+                    }
+                }
+
+                String networking = request.request.slaveInfo.getContainerInfo().getNetworking();
+                dockerInfoBuilder.setNetwork(Network.valueOf(networking));
+
+                //  https://github.com/jenkinsci/mesos-plugin/issues/109
+                if (dockerInfoBuilder.getNetwork() != Network.HOST) {
+                    containerInfoBuilder.setHostname(slaveName);
+                }
+
+                if (request.request.slaveInfo.getContainerInfo().hasPortMappings()) {
+                    List<MesosSlaveInfo.PortMapping> portMappings = request.request.slaveInfo.getContainerInfo().getPortMappings();
+                    Set<Long> portsToUse = findPortsToUse(offer, portMappings.size());
+                    String roleToUse = findRoleForPorts(offer);
+                    Iterator<Long> iterator = portsToUse.iterator();
+                    Value.Ranges.Builder portRangesBuilder = Value.Ranges.newBuilder();
+
+                    for (MesosSlaveInfo.PortMapping portMapping : portMappings) {
+                        PortMapping.Builder portMappingBuilder = PortMapping.newBuilder() //
+                                .setContainerPort(portMapping.getContainerPort()) //
+                                .setProtocol(portMapping.getProtocol());
+
+                        Long portToUse = portMapping.getHostPort() == null ? iterator.next() : Long.valueOf(portMapping.getHostPort());
+
+                        portMappingBuilder.setHostPort(portToUse.intValue());
+
+                        portRangesBuilder.addRange(
+                                Value.Range
+                                        .newBuilder()
+                                        .setBegin(portToUse)
+                                        .setEnd(portToUse)
+                        );
+
+                        LOGGER.finest("Adding portMapping: " + portMapping);
+                        dockerInfoBuilder.addPortMappings(portMappingBuilder);
+                    }
+
+                    taskBuilder.addResources(
+                            Resource
+                                    .newBuilder()
+                                    .setName("ports")
+                                    .setType(Value.Type.RANGES)
+                                    .setRole(roleToUse)
+                                    .setRanges(portRangesBuilder)
+                    );
+                } else {
+                    LOGGER.fine("No portMappings found");
+                }
+
+                containerInfoBuilder.setDocker(dockerInfoBuilder);
+                break;
+            default:
+                LOGGER.warning("Unknown container type:" + containerInfo.getType());
+        }
+
+        if (containerInfo.getVolumes() != null) {
+            for (MesosSlaveInfo.Volume volume : containerInfo.getVolumes()) {
+                LOGGER.info("Adding volume '" + volume.getContainerPath() + "'");
+                Volume.Builder volumeBuilder = Volume.newBuilder()
+                        .setContainerPath(volume.getContainerPath())
+                        .setMode(volume.isReadOnly() ? Mode.RO : Mode.RW);
+                if (!volume.getHostPath().isEmpty()) {
+                    volumeBuilder.setHostPath(volume.getHostPath());
+                }
+                containerInfoBuilder.addVolumes(volumeBuilder.build());
+            }
+        }
+
+        if (containerInfo.hasNetworkInfos()) {
+            for (MesosSlaveInfo.NetworkInfo networkInfo : containerInfo.getNetworkInfos()) {
+
+                NetworkInfo.Builder networkInfoBuilder = NetworkInfo.newBuilder();
+
+                if (networkInfo.hasNetworkName()) {
+                    //Add the virtual network specified, trimming edges for whitespace
+                    networkInfoBuilder.setName(networkInfo.getNetworkName().trim());
+                    LOGGER.info("Launching container on network " + networkInfo.getNetworkName() );
+                }
+
+                containerInfoBuilder.addNetworkInfos(networkInfoBuilder.build());
+            }
+        }
+
+        taskBuilder.setContainer(containerInfoBuilder.build());
+    }
+
+    @VisibleForTesting
+    CommandInfo.Builder getCommandInfoBuilder(Request request) {
         CommandInfo.Builder commandBuilder = getBaseCommandBuilder(request);
         detectAndAddAdditionalURIs(request, commandBuilder);
         return commandBuilder;
-  }
+    }
 
-  String generateJenkinsCommand2Run(int jvmMem,String jvmArgString,String jnlpArgString,String slaveName) {
+    String generateJenkinsCommand2Run(int jvmMem,String jvmArgString,String jnlpArgString,String slaveName) {
 
-      return String.format(SLAVE_COMMAND_FORMAT,
-              jvmMem,
-              jvmArgString,
-              jnlpArgString,
-              getJnlpSecret(slaveName),
-              getJnlpUrl(slaveName));
-  }
+        return String.format(SLAVE_COMMAND_FORMAT,
+                jvmMem,
+                jvmArgString,
+                jnlpArgString,
+                getJnlpSecret(slaveName),
+                getJnlpUrl(slaveName));
+    }
 
-  private CommandInfo.Builder getBaseCommandBuilder(Request request) {
+    private CommandInfo.Builder getBaseCommandBuilder(Request request) {
 
         CommandInfo.Builder commandBuilder = CommandInfo.newBuilder();
         String jenkinsCommand2Run = generateJenkinsCommand2Run(
-            request.request.slaveInfo.getSlaveMem(),
-            request.request.slaveInfo.getJvmArgs(),
-            request.request.slaveInfo.getJnlpArgs(),
-            request.request.slave.name);
+                request.request.slaveInfo.getSlaveMem(),
+                request.request.slaveInfo.getJvmArgs(),
+                request.request.slaveInfo.getJnlpArgs(),
+                request.request.slave.name);
 
         if (request.request.slaveInfo.getContainerInfo() != null &&
-            request.request.slaveInfo.getContainerInfo().getUseCustomDockerCommandShell()) {
+                request.request.slaveInfo.getContainerInfo().getUseCustomDockerCommandShell()) {
             // Ref http://mesos.apache.org/documentation/latest/upgrades
             // regarding setting the shell value, and the impact on the command to be
             // launched
@@ -897,220 +896,220 @@ public class JenkinsScheduler implements Scheduler {
             args.add(jenkinsCommand2Run);
             commandBuilder.addAllArguments( args );
 
-    } else {
-        LOGGER.fine("About to use default shell ....");
-        commandBuilder.setValue(jenkinsCommand2Run);
+        } else {
+            LOGGER.fine("About to use default shell ....");
+            commandBuilder.setValue(jenkinsCommand2Run);
+        }
+
+        commandBuilder.addUris(
+                CommandInfo.URI.newBuilder().setValue(
+                        joinPaths(jenkinsMaster, SLAVE_JAR_URI_SUFFIX)).setExecutable(false).setExtract(false));
+        return commandBuilder;
     }
 
-    commandBuilder.addUris(
-        CommandInfo.URI.newBuilder().setValue(
-            joinPaths(jenkinsMaster, SLAVE_JAR_URI_SUFFIX)).setExecutable(false).setExtract(false));
-    return commandBuilder;
-  }
+    /**
+     * Checks if the given taskId already exists or just finished running. If it has, then refuse the offer.
+     * @param taskId The task id
+     * @return True if the task already exists, false otherwise
+     */
+    @VisibleForTesting
+    boolean isExistingTask(TaskID taskId) {
+        // If the task has already been queued, don't launch it again
+        if (results.containsKey(taskId)) {
+            LOGGER.info("Task " + taskId.getValue() + " has already been launched, ignoring and refusing offer");
+            return true;
+        }
 
-  /**
-   * Checks if the given taskId already exists or just finished running. If it has, then refuse the offer.
-   * @param taskId The task id
-   * @return True if the task already exists, false otherwise
-   */
-  @VisibleForTesting
-  boolean isExistingTask(TaskID taskId) {
-      // If the task has already been queued, don't launch it again
-      if (results.containsKey(taskId)) {
-          LOGGER.info("Task " + taskId.getValue() + " has already been launched, ignoring and refusing offer");
-          return true;
-      }
+        // If the task has already finished, then do not start it up again even if we are offered it
+        if (finishedTasks.contains(taskId)) {
+            LOGGER.info("Task " + taskId.getValue() + " has already finished. Ignoring and refusing offer");
+            return true;
+        }
 
-      // If the task has already finished, then do not start it up again even if we are offered it
-      if (finishedTasks.contains(taskId)) {
-          LOGGER.info("Task " + taskId.getValue() + " has already finished. Ignoring and refusing offer");
-          return true;
-      }
+        return false;
+    }
 
-      return false;
-  }
+    /**
+     * Refuses the offer provided by launching no tasks.
+     * @param offer The offer to refuse
+     */
+    @VisibleForTesting
+    void refuseOffer(Offer offer) {
+        driver.declineOffer(offer.getId());
+    }
 
-  /**
-   * Refuses the offer provided by launching no tasks.
-   * @param offer The offer to refuse
-   */
-  @VisibleForTesting
-  void refuseOffer(Offer offer) {
-      driver.declineOffer(offer.getId());
-  }
+    @Override
+    public void offerRescinded(SchedulerDriver driver, OfferID offerId) {
+        LOGGER.info("Rescinded offer " + offerId);
+    }
 
-  @Override
-  public void offerRescinded(SchedulerDriver driver, OfferID offerId) {
-    LOGGER.info("Rescinded offer " + offerId);
-  }
-
-  @Override
-  public void statusUpdate(SchedulerDriver driver, TaskStatus status) {
-    TaskID taskId = status.getTaskId();
-    LOGGER.fine("Status update: task " + taskId + " is in state " + status.getState() +
+    @Override
+    public void statusUpdate(SchedulerDriver driver, TaskStatus status) {
+        TaskID taskId = status.getTaskId();
+        LOGGER.fine("Status update: task " + taskId + " is in state " + status.getState() +
                 (status.hasMessage() ? " with message '" + status.getMessage() + "'" : ""));
 
-    if (!results.containsKey(taskId)) {
-      // The task might not be present in the 'results' map if this is a duplicate terminal
-      // update.
-      LOGGER.fine("Ignoring status update " + status.getState() + " for unknown task " + taskId);
-      return;
-    }
-
-    Result result = results.get(taskId);
-    boolean terminalState = false;
-
-    switch (status.getState()) {
-    case TASK_STAGING:
-    case TASK_STARTING:
-      break;
-    case TASK_RUNNING:
-      result.result.running(result.slave);
-      break;
-    case TASK_FINISHED:
-      result.result.finished(result.slave);
-      terminalState = true;
-      break;
-    case TASK_ERROR:
-    case TASK_FAILED:
-    case TASK_KILLED:
-    case TASK_LOST:
-      result.result.failed(result.slave);
-      terminalState = true;
-      break;
-    default:
-      throw new IllegalStateException("Invalid State: " + status.getState());
-    }
-
-    if (terminalState) {
-      results.remove(taskId);
-    }
-
-    if (mesosCloud.isOnDemandRegistration()) {
-      supervise();
-    }
-  }
-
-  @Override
-  public void frameworkMessage(SchedulerDriver driver, ExecutorID executorId,
-      SlaveID slaveId, byte[] data) {
-    LOGGER.info("Received framework message from executor " + executorId
-        + " of slave " + slaveId);
-  }
-
-  @Override
-  public void slaveLost(SchedulerDriver driver, SlaveID slaveId) {
-    LOGGER.info("Slave " + slaveId + " lost!");
-  }
-
-  @Override
-  public void executorLost(SchedulerDriver driver, ExecutorID executorId,
-      SlaveID slaveId, int status) {
-    LOGGER.info("Executor " + executorId + " of slave " + slaveId + " lost!");
-  }
-
-  @Override
-  public void error(SchedulerDriver driver, String message) {
-    LOGGER.severe(message);
-  }
-
-  /**
-  * @return the mesosCloud
-  */
-  private MesosCloud getMesosCloud() {
-    return mesosCloud;
-  }
-
-  /**
-  * @param mesosCloud the mesosCloud to set
-  */
-  protected void setMesosCloud(MesosCloud mesosCloud) {
-    this.mesosCloud = mesosCloud;
-  }
-
-  private static class Result {
-    private final Mesos.SlaveResult result;
-    private final Mesos.JenkinsSlave slave;
-
-    private Result(Mesos.SlaveResult result, Mesos.JenkinsSlave slave) {
-      this.result = result;
-      this.slave = slave;
-    }
-  }
-
-  @VisibleForTesting
-  static class Request {
-    private final Mesos.SlaveRequest request;
-    private final Mesos.SlaveResult result;
-
-    public Request(Mesos.SlaveRequest request, Mesos.SlaveResult result) {
-      this.request = request;
-      this.result = result;
-    }
-  }
-
-  public int getNumberofPendingTasks() {
-    return requests.size();
-  }
-
-  public int getNumberOfActiveTasks() {
-    return results.size();
-  }
-
-  public void clearResults() {
-    results.clear();
-  }
-
-  /**
-   * Disconnect framework, if we don't have active mesos slaves. Also, make
-   * sure JenkinsScheduler's request queue is empty.
-   */
-  public static void supervise() {
-    try {
-      SUPERVISOR_LOCK.lock();
-      Collection<Mesos> clouds = Mesos.getAllClouds();
-      for (Mesos cloud : clouds) {
-        try {
-          JenkinsScheduler scheduler = (JenkinsScheduler) cloud.getScheduler();
-          if (scheduler != null) {
-            boolean pendingTasks = (scheduler.getNumberofPendingTasks() > 0);
-            boolean activeSlaves = false;
-            boolean activeTasks = (scheduler.getNumberOfActiveTasks() > 0);
-            List<Node> slaveNodes = getJenkins().getNodes();
-            for (Node node : slaveNodes) {
-              if (node instanceof MesosSlave) {
-                activeSlaves = true;
-                break;
-              }
-            }
-            // If there are no active slaves, we should clear up results.
-            if (!activeSlaves) {
-              scheduler.clearResults();
-              activeTasks = false;
-            }
-            LOGGER.fine("Active slaves: " + activeSlaves
-                + " | Pending tasks: " + pendingTasks + " | Active tasks: " + activeTasks);
-            if (!activeTasks && !activeSlaves && !pendingTasks) {
-              LOGGER.info("No active tasks, or slaves or pending slave requests. Stopping the scheduler.");
-              cloud.stopScheduler();
-            }
-          } else {
-            LOGGER.info("Scheduler already stopped. NOOP.");
-          }
-        } catch (Exception e) {
-          LOGGER.info("Exception: " + e);
+        if (!results.containsKey(taskId)) {
+            // The task might not be present in the 'results' map if this is a duplicate terminal
+            // update.
+            LOGGER.fine("Ignoring status update " + status.getState() + " for unknown task " + taskId);
+            return;
         }
-      }
-    } finally {
-      SUPERVISOR_LOCK.unlock();
+
+        Result result = results.get(taskId);
+        boolean terminalState = false;
+
+        switch (status.getState()) {
+            case TASK_STAGING:
+            case TASK_STARTING:
+                break;
+            case TASK_RUNNING:
+                result.result.running(result.slave);
+                break;
+            case TASK_FINISHED:
+                result.result.finished(result.slave);
+                terminalState = true;
+                break;
+            case TASK_ERROR:
+            case TASK_FAILED:
+            case TASK_KILLED:
+            case TASK_LOST:
+                result.result.failed(result.slave);
+                terminalState = true;
+                break;
+            default:
+                throw new IllegalStateException("Invalid State: " + status.getState());
+        }
+
+        if (terminalState) {
+            results.remove(taskId);
+        }
+
+        if (mesosCloud.isOnDemandRegistration()) {
+            supervise();
+        }
     }
-  }
 
-  public String getJenkinsMaster() {
-    return jenkinsMaster;
-  }
+    @Override
+    public void frameworkMessage(SchedulerDriver driver, ExecutorID executorId,
+                                 SlaveID slaveId, byte[] data) {
+        LOGGER.info("Received framework message from executor " + executorId
+                + " of slave " + slaveId);
+    }
 
-  public void setJenkinsMaster(String jenkinsMaster) {
-    this.jenkinsMaster = jenkinsMaster;
-  }
+    @Override
+    public void slaveLost(SchedulerDriver driver, SlaveID slaveId) {
+        LOGGER.info("Slave " + slaveId + " lost!");
+    }
+
+    @Override
+    public void executorLost(SchedulerDriver driver, ExecutorID executorId,
+                             SlaveID slaveId, int status) {
+        LOGGER.info("Executor " + executorId + " of slave " + slaveId + " lost!");
+    }
+
+    @Override
+    public void error(SchedulerDriver driver, String message) {
+        LOGGER.severe(message);
+    }
+
+    /**
+     * @return the mesosCloud
+     */
+    private MesosCloud getMesosCloud() {
+        return mesosCloud;
+    }
+
+    /**
+     * @param mesosCloud the mesosCloud to set
+     */
+    protected void setMesosCloud(MesosCloud mesosCloud) {
+        this.mesosCloud = mesosCloud;
+    }
+
+    private static class Result {
+        private final Mesos.SlaveResult result;
+        private final Mesos.JenkinsSlave slave;
+
+        private Result(Mesos.SlaveResult result, Mesos.JenkinsSlave slave) {
+            this.result = result;
+            this.slave = slave;
+        }
+    }
+
+    @VisibleForTesting
+    static class Request {
+        private final Mesos.SlaveRequest request;
+        private final Mesos.SlaveResult result;
+
+        public Request(Mesos.SlaveRequest request, Mesos.SlaveResult result) {
+            this.request = request;
+            this.result = result;
+        }
+    }
+
+    public int getNumberofPendingTasks() {
+        return requests.size();
+    }
+
+    public int getNumberOfActiveTasks() {
+        return results.size();
+    }
+
+    public void clearResults() {
+        results.clear();
+    }
+
+    /**
+     * Disconnect framework, if we don't have active mesos slaves. Also, make
+     * sure JenkinsScheduler's request queue is empty.
+     */
+    public static void supervise() {
+        try {
+            SUPERVISOR_LOCK.lock();
+            Collection<Mesos> clouds = Mesos.getAllClouds();
+            for (Mesos cloud : clouds) {
+                try {
+                    JenkinsScheduler scheduler = (JenkinsScheduler) cloud.getScheduler();
+                    if (scheduler != null) {
+                        boolean pendingTasks = (scheduler.getNumberofPendingTasks() > 0);
+                        boolean activeSlaves = false;
+                        boolean activeTasks = (scheduler.getNumberOfActiveTasks() > 0);
+                        List<Node> slaveNodes = getJenkins().getNodes();
+                        for (Node node : slaveNodes) {
+                            if (node instanceof MesosSlave) {
+                                activeSlaves = true;
+                                break;
+                            }
+                        }
+                        // If there are no active slaves, we should clear up results.
+                        if (!activeSlaves) {
+                            scheduler.clearResults();
+                            activeTasks = false;
+                        }
+                        LOGGER.fine("Active slaves: " + activeSlaves
+                                + " | Pending tasks: " + pendingTasks + " | Active tasks: " + activeTasks);
+                        if (!activeTasks && !activeSlaves && !pendingTasks) {
+                            LOGGER.info("No active tasks, or slaves or pending slave requests. Stopping the scheduler.");
+                            cloud.stopScheduler();
+                        }
+                    } else {
+                        LOGGER.info("Scheduler already stopped. NOOP.");
+                    }
+                } catch (Exception e) {
+                    LOGGER.info("Exception: " + e);
+                }
+            }
+        } finally {
+            SUPERVISOR_LOCK.unlock();
+        }
+    }
+
+    public String getJenkinsMaster() {
+        return jenkinsMaster;
+    }
+
+    public void setJenkinsMaster(String jenkinsMaster) {
+        this.jenkinsMaster = jenkinsMaster;
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -28,13 +28,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
-import hudson.model.Computer;
-import hudson.model.Descriptor;
-import hudson.model.Hudson;
-import hudson.model.Item;
-import hudson.model.Label;
-import hudson.model.Node;
-import hudson.model.listeners.SaveableListener;
+import hudson.model.*;
 import hudson.security.ACL;
 import hudson.slaves.Cloud;
 import hudson.slaves.NodeProvisioner.PlannedNode;
@@ -43,6 +37,7 @@ import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.apache.mesos.MesosNativeLibrary;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -50,11 +45,9 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
-import org.apache.commons.lang.StringUtils;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import java.io.IOException;
-import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.*;
@@ -64,6 +57,7 @@ import java.util.logging.Logger;
 
 public class MesosCloud extends Cloud {
   private static final String DEFAULT_DECLINE_OFFER_DURATION = "600000"; // 10 mins.
+  public static final double SHORT_DECLINE_OFFER_DURATION_SEC = 5;
   private String nativeLibraryPath;
   private String master;
   private String description;

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosImpl.java
@@ -15,7 +15,7 @@ public class MesosImpl extends Mesos {
     }
     lock();
     try {
-      scheduler = new JenkinsScheduler(jenkinsMaster, mesosCloud);
+      scheduler = new JenkinsScheduler(jenkinsMaster, mesosCloud, true);
       scheduler.init();
     } finally {
       unlock();

--- a/src/main/java/org/jenkinsci/plugins/mesos/OfferQueue.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/OfferQueue.java
@@ -1,0 +1,116 @@
+package org.jenkinsci.plugins.mesos;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.mesos.Protos;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * This class acts as a buffer of Offers from Mesos.  By default it holds a maximum of 100 Offers.
+ */
+public class OfferQueue {
+    private static final int DEFAULT_CAPACITY = 100;
+    private static final Duration DEFAULT_OFFER_WAIT = Duration.ofSeconds(5);
+    //private final Logger logger = LoggingUtils.getLogger(getClass());
+    private final BlockingQueue<Protos.Offer> queue;
+
+    public OfferQueue() {
+        this(DEFAULT_CAPACITY);
+    }
+
+    /**
+     * Creates a new queue with the provided capacity.
+     *
+     * @param capacity the maximum size of the queue, or zero for unlimited queue size
+     */
+    public OfferQueue(int capacity) {
+        this.queue = capacity == 0 ? new LinkedBlockingQueue<>() : new LinkedBlockingQueue<>(capacity);
+    }
+
+    /**
+     * Calling this method will wait for Offers for the provided duration.
+     * It returns all Offers currently in the queue if any are present and none otherwise.
+     */
+    public List<Protos.Offer> takeAll(Duration duration) {
+        List<Protos.Offer> offers = new LinkedList<>();
+        try {
+            // The poll() waits for one Offer or returns null if none is present within the timeout.  The following
+            // drainTo() call will pull the following Offers (if any) off the queue and return.
+            Protos.Offer offer = queue.poll(duration.getSeconds(), TimeUnit.SECONDS);
+            if (offer != null) {
+                offers.add(offer);
+            }
+
+            queue.drainTo(offers);
+        } catch (InterruptedException e) {
+            //logger.warn("Interrupted while waiting for offer in queue.");
+        }
+
+        return offers;
+    }
+
+    /**
+     * Calling this method will wait for Offers for a static duration of {@link OfferQueue#DEFAULT_CAPACITY}.
+     * It returns all Offers currently in the queue if any are present and an empty list if the duration
+     * of {@link OfferQueue#DEFAULT_OFFER_WAIT} is reached.
+     */
+    public List<Protos.Offer> takeAll() {
+        return takeAll(DEFAULT_OFFER_WAIT);
+    }
+
+    /**
+     * This method enqueues an Offer from Mesos if there is capacity. If there is not capacity the Offer is not added
+     * to the queue.
+     * @return true if the Offer was successfully put in the queue, false otherwise
+     */
+    public boolean offer(Protos.Offer offer) {
+        return queue.offer(offer);
+    }
+
+    /**
+     * This method removes an offer from the queue based on its OfferID.
+     */
+    public void remove(Protos.OfferID offerID) {
+        Collection<Protos.Offer> offers = queue.parallelStream()
+                .filter(offer -> offer.getId().equals(offerID))
+                .collect(Collectors.toList());
+
+        boolean removed = queue.removeAll(offers);
+        if (!removed) {
+            //logger.warn("Attempted to remove offer: '{}' but it was not present in the queue.", offerID.getValue());
+        } else {
+            //logger.info("Removed offer: {}", offerID.getValue());
+        }
+    }
+
+    /**
+     * This method specifies whether any offers are in the queue.
+     */
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+
+    /**
+     * This method returns the number of elements in the queue.
+     */
+    @VisibleForTesting
+    int getSize() {
+        return queue.size();
+    }
+
+    /**
+     * This method returns the remaining capacity in the queue.
+     */
+    @VisibleForTesting
+    int getRemainingCapacity() {
+        return queue.remainingCapacity();
+    }
+}
+

--- a/src/main/java/org/jenkinsci/plugins/mesos/OfferQueue.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/OfferQueue.java
@@ -10,15 +10,17 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
  * This class acts as a buffer of Offers from Mesos.  By default it holds a maximum of 100 Offers.
  */
 public class OfferQueue {
+    private final Logger logger = Logger.getLogger(JenkinsScheduler.class.getName());
+
     private static final int DEFAULT_CAPACITY = 100;
     private static final Duration DEFAULT_OFFER_WAIT = Duration.ofSeconds(5);
-    //private final Logger logger = LoggingUtils.getLogger(getClass());
     private final BlockingQueue<Protos.Offer> queue;
 
     public OfferQueue() {
@@ -50,14 +52,14 @@ public class OfferQueue {
 
             queue.drainTo(offers);
         } catch (InterruptedException e) {
-            //logger.warn("Interrupted while waiting for offer in queue.");
+            logger.warning("Interrupted while waiting for offer in queue.");
         }
 
         return offers;
     }
 
     /**
-     * Calling this method will wait for Offers for a static duration of {@link OfferQueue#DEFAULT_CAPACITY}.
+     * Calling this method will wait for Offers for a static duration of {@link OfferQueue#DEFAULT_OFFER_WAIT}.
      * It returns all Offers currently in the queue if any are present and an empty list if the duration
      * of {@link OfferQueue#DEFAULT_OFFER_WAIT} is reached.
      */
@@ -84,9 +86,12 @@ public class OfferQueue {
 
         boolean removed = queue.removeAll(offers);
         if (!removed) {
-            //logger.warn("Attempted to remove offer: '{}' but it was not present in the queue.", offerID.getValue());
+            logger.warning(
+                    String.format(
+                            "Attempted to remove offer: '%s' but it was not present in the queue.",
+                            offerID.getValue()));
         } else {
-            //logger.info("Removed offer: {}", offerID.getValue());
+            logger.info(String.format("Removed offer: %s", offerID.getValue()));
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -59,8 +59,7 @@ public class JenkinsSchedulerTest {
         PowerMockito.mockStatic(Jenkins.class);
         Mockito.when(Jenkins.getInstance()).thenReturn(jenkins);
 
-        jenkinsScheduler = new JenkinsScheduler("jenkinsMaster", mesosCloud);
-
+        jenkinsScheduler = new JenkinsScheduler("jenkinsMaster", mesosCloud, false);
     }
 
     @Test
@@ -173,6 +172,7 @@ public class JenkinsSchedulerTest {
         Mockito.when(jenkins.getQueue()).thenReturn(queue);
 
         SchedulerDriver driver = Mockito.mock(SchedulerDriver.class);
+        jenkinsScheduler.setDriver(driver);
         Mockito.when(mesosCloud.getDeclineOfferDurationDouble()).thenReturn((double) 120000);
         jenkinsScheduler.resourceOffers(driver, offers);
         Mockito.verify(driver, Mockito.never()).declineOffer(offer.getId());
@@ -189,6 +189,7 @@ public class JenkinsSchedulerTest {
         offers.add(offer);
 
         SchedulerDriver driver = Mockito.mock(SchedulerDriver.class);
+        jenkinsScheduler.setDriver(driver);
         Mockito.when(mesosCloud.getDeclineOfferDurationDouble()).thenReturn((double) 120000);
         jenkinsScheduler.resourceOffers(driver, offers);
         Mockito.verify(driver).declineOffer(offer.getId());
@@ -210,6 +211,7 @@ public class JenkinsSchedulerTest {
         Mockito.when(mesosCloud.canProvision(null)).thenReturn(true);
 
         SchedulerDriver driver = Mockito.mock(SchedulerDriver.class);
+        jenkinsScheduler.setDriver(driver);
         Mockito.when(mesosCloud.getDeclineOfferDurationDouble()).thenReturn((double) 120000);
         jenkinsScheduler.resourceOffers(driver, offers);
         Mockito.verify(driver).declineOffer(offer.getId());

--- a/src/test/java/org/jenkinsci/plugins/mesos/OfferQueueTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/OfferQueueTest.java
@@ -1,0 +1,142 @@
+package org.jenkinsci.plugins.mesos;
+
+import org.apache.mesos.Protos;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * This class tests the {@link OfferQueue}.
+ */
+public class OfferQueueTest {
+    private static final int TEST_CAPACITY = 10;
+    public static final Protos.OfferID OFFER_ID = Protos.OfferID.newBuilder().setValue("test-offer-id").build();
+    public static final Protos.SlaveID AGENT_ID = Protos.SlaveID.newBuilder().setValue("test-slave-id").build();
+    public static final String HOSTNAME = "test-hostname";
+
+    public static final Protos.FrameworkID FRAMEWORK_ID =
+            Protos.FrameworkID.newBuilder()
+                    .setValue("test-framework-id")
+                    .build();
+
+    @Test
+    public void testEmptyQueue() {
+        OfferQueue offerQueue = new OfferQueue();
+        Assert.assertTrue(offerQueue.isEmpty());
+    }
+
+    @Test
+    public void testEnqueueOffer() {
+        OfferQueue offerQueue = new OfferQueue(TEST_CAPACITY);
+        offerQueue.offer(getOffer());
+        Assert.assertEquals(1, offerQueue.getSize());
+        Assert.assertEquals(TEST_CAPACITY - 1, offerQueue.getRemainingCapacity());
+    }
+
+    @Test
+    public void testExceedCapacity() {
+        OfferQueue offerQueue = new OfferQueue();
+        int capacity = offerQueue.getRemainingCapacity();
+        for (int i = 0; i < capacity; i++) {
+            Assert.assertTrue(offerQueue.offer(getOffer()));
+        }
+
+        Assert.assertEquals(0, offerQueue.getRemainingCapacity());
+        Assert.assertFalse(offerQueue.offer(getOffer()));
+    }
+
+    @Test
+    public void testTakeOne() {
+        OfferQueue offerQueue = new OfferQueue(TEST_CAPACITY);
+        offerQueue.offer(getOffer());
+        List<Protos.Offer> offers = offerQueue.takeAll();
+        Assert.assertEquals(1, offers.size());
+        Assert.assertEquals(TEST_CAPACITY, offerQueue.getRemainingCapacity());
+    }
+
+    @Test
+    public void testTakeMultiple() {
+        OfferQueue offerQueue = new OfferQueue(TEST_CAPACITY);
+        int halfCapacity = offerQueue.getRemainingCapacity() / 2;
+        for (int i = 0; i < halfCapacity; i++) {
+            offerQueue.offer(getOffer());
+        }
+
+        List<Protos.Offer> offers = offerQueue.takeAll();
+        Assert.assertEquals(halfCapacity, offers.size());
+        Assert.assertEquals(TEST_CAPACITY, offerQueue.getRemainingCapacity());
+    }
+
+    @Test
+    public void testTakeFull() {
+        OfferQueue offerQueue = new OfferQueue(TEST_CAPACITY);
+        int capacity = offerQueue.getRemainingCapacity();
+        for (int i = 0; i < capacity; i++) {
+            offerQueue.offer(getOffer());
+        }
+
+        List<Protos.Offer> offers = offerQueue.takeAll();
+        Assert.assertEquals(capacity, offers.size());
+        Assert.assertEquals(TEST_CAPACITY, offerQueue.getRemainingCapacity());
+    }
+
+    @Test
+    public void testRemoveFromEmptyQueue() {
+        OfferQueue offerQueue = new OfferQueue();
+        Assert.assertTrue(offerQueue.isEmpty());
+        offerQueue.remove(OFFER_ID);
+        Assert.assertTrue(offerQueue.isEmpty());
+    }
+
+    @Test
+    public void testRemoveFromSingleOfferQueue() {
+        OfferQueue offerQueue = new OfferQueue();
+        offerQueue.offer(getOffer());
+        Assert.assertEquals(1, offerQueue.getSize());
+        offerQueue.remove(OFFER_ID);
+        Assert.assertTrue(offerQueue.isEmpty());
+    }
+
+    @Test
+    public void testRemoveUnknownOffer() {
+        OfferQueue offerQueue = new OfferQueue();
+        offerQueue.offer(getOffer(UUID.randomUUID().toString()));
+        Assert.assertEquals(1, offerQueue.getSize());
+        offerQueue.remove(OFFER_ID);
+        Assert.assertEquals(1, offerQueue.getSize());
+    }
+
+    @Test
+    public void testRemoveOneLeaveOthers() {
+        OfferQueue offerQueue = new OfferQueue();
+        int halfCapacity = offerQueue.getRemainingCapacity() / 2;
+        // Add many offers with random ids
+        for (int i = 0; i < halfCapacity; i++) {
+            offerQueue.offer(getOffer(UUID.randomUUID().toString()));
+        }
+
+        // Add one offer with a known id
+        offerQueue.offer(getOffer());
+
+        int remainingCapacity = offerQueue.getRemainingCapacity();
+        offerQueue.remove(OFFER_ID);
+        // Expect capacity to increase by one as we've removed one known offer
+        Assert.assertEquals(remainingCapacity + 1, offerQueue.getRemainingCapacity());
+    }
+
+    private Protos.Offer getOffer() {
+        return getOffer(OFFER_ID.getValue());
+    }
+
+    private Protos.Offer getOffer(String id) {
+        return Protos.Offer.newBuilder()
+                .setId(Protos.OfferID.newBuilder().setValue(id))
+                .setFrameworkId(FRAMEWORK_ID)
+                .setSlaveId(AGENT_ID)
+                .setHostname(HOSTNAME)
+                .build();
+    }
+}
+


### PR DESCRIPTION
### Problem ###
The Mesos scheduler does not keep up with the rate of offers.  Eventually offers back up to such a degree that they are not processed within the offer timeout (10 min).  The offers are then rescinded which the scheduler also doesn't handle.  Then later the scheduler tries to consume rescinded offers which is an illegal operation.

### Solution ###
Process offers properly.  Offers are handled very quickly by putting them on an in memory queue.  The offer thread is released more or less immediately.  A second thread pulls offers off the queue for handling.  If the offer queue is full offers are declined for a brief period (5 sec) by which point room in the offer queue will have freed up.

#### NOTE ####
This diff can be hard to read because I moved the JenkinsScheduler.java file to 4 space indentation.  Include `?w=1` at the end of the PR url to ignore whitespace and see a clearer diff.