### PR TITLE
Do not use a higher version of Guava than Jenkins.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.6</powermock.version>
     <assertj.version>2.1.0</assertj.version>
-    <guava.version>18.0</guava.version>
+    <guava.version>11.0.1</guava.version>
     <apache-commons-collections.version>4.1</apache-commons-collections.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,6 @@
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.6</powermock.version>
     <assertj.version>2.1.0</assertj.version>
-    <guava.version>11.0.1</guava.version>
     <apache-commons-collections.version>4.1</apache-commons-collections.version>
   </properties>
 
@@ -154,11 +153,6 @@
           <artifactId>assertj-core</artifactId>
           <version>${assertj.version}</version>
           <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-          <version>${guava.version}</version>
       </dependency>
       <dependency>
           <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Guava is bundled in Jenkins and at a much lower version, so this is
asking for issue to happen.  e.g. [JENKINS-51889](https://issues.jenkins-ci.org/browse/JENKINS-51889) jenkinsci/workflow-cps-plugin#231