### PR TITLE
do not have a release version on master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>mesos</artifactId>
-  <version>0.16.101</version>
+  <version>0.16.102-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Mesos+Plugin</url>
   <description>Allows the dynamic launch Jenkins agent on a Mesos cluster, depending on workload</description>


### PR DESCRIPTION
releases should be made with the `maven-release-plugin` or other, but release versions must never be set on the tip of a branch, just tags.