### PR TITLE
Add radioBlock for USER networking on config.jelly

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/ContainerInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/ContainerInfo/config.jelly
@@ -38,6 +38,7 @@
                 </f:repeatableProperty>
             </f:entry>
         </f:radioBlock>
+        <f:radioBlock id="networking.USER" name="networking" title="${%User}" value="USER" inline="true" checked="${instance.networking == null || instance.networking == 'USER'}" />
     </f:entry>
 
     <f:entry title="${%Network Info}">


### PR DESCRIPTION
The option to put the USER-type network is added in the containerInfo configuration file.