### PR TITLE
Fix #331 - Make Metrics dependency not optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,6 @@
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>metrics</artifactId>
           <version>3.1.2.6</version>
-          <optional>true</optional>
       </dependency>
   </dependencies>
   <dependencyManagement>


### PR DESCRIPTION
With this quick fix i was able to install and configure a Mesos Cloud successfully on a new Jenkins instance #331 