### PR TITLE
several fixes and changes on stability, usability and readablity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+    apt-get install -y default-jdk maven && \
+    rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data", "/root/.m2"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cd /data && mvn package

--- a/dkbd.sh
+++ b/dkbd.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir -p maven-repo
+docker-compose run builder /data/build.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  builder:
+    image: maven
+    volumes:
+      - .:/data
+      - ./maven-repo:/root/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,14 @@
                   </systemProperties>
               </configuration>
           </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
+            </plugin>
       </plugins>
   </build>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -41,7 +41,20 @@ import org.apache.mesos.Protos.Volume.Mode;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 
-import java.util.*;
+import java.util.Queue;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.HashSet;
+import java.util.TreeSet;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Date;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -90,7 +103,7 @@ public class JenkinsScheduler implements Scheduler {
 
     private static final Object IGNORE = new Object();
 
-    private static final OfferQueue offerQueue = new OfferQueue();
+    private final OfferQueue offerQueue = new OfferQueue();
     private Thread offerProcessingThread = null;
     private volatile FrameworkID frameworkId;
 
@@ -423,7 +436,7 @@ public class JenkinsScheduler implements Scheduler {
             public void run() {
                 LOGGER.info("Started offer processing thread: " + threadName);
                 try {
-                    while (true) {
+                    while (isRunning()) {
                         processOffers();
                     }
                 } catch (Throwable t) {

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -635,20 +635,17 @@ public class JenkinsScheduler implements Scheduler {
         //Accept any and all Mesos slave offers by default.
         boolean slaveTypeMatch = true;
 
-        //Collect the list of attributes from the offer as key-value pairs
-        Map<String, String> attributesMap = new HashMap<String, String>();
-        for (Attribute attribute : offer.getAttributesList()) {
-            attributesMap.put(attribute.getName(), attribute.getText().getValue());
-        }
-
         if (slaveAttributes != null && slaveAttributes.size() > 0) {
+            //Collect the list of attributes from the offer as key-value pairs
+            Map<String, String> attributesMap = new HashMap<String, String>();
+            for (Attribute attribute : offer.getAttributesList()) {
+                attributesMap.put(attribute.getName(), attribute.getText().getValue());
+            }
 
             //Iterate over the cloud attributes to see if they exist in the offer attributes list.
             Iterator iterator = slaveAttributes.keys();
             while (iterator.hasNext()) {
-
                 String key = (String) iterator.next();
-
                 //If there is a single absent attribute then we should reject this offer.
                 if (!(attributesMap.containsKey(key) && attributesMap.get(key).toString().equals(slaveAttributes.getString(key)))) {
                     slaveTypeMatch = false;

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCleanupThread.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCleanupThread.java
@@ -122,7 +122,6 @@ public class MesosCleanupThread extends AsyncPeriodicWork {
             } catch (InterruptedException e) {
                 logger.log(Level.WARNING, "Failed to disconnect and delete " + c.getName() + ": " + e.getMessage());
             }
-
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -61,7 +61,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class MesosCloud extends Cloud {
-  private static final String DEFAULT_DECLINE_OFFER_DURATION = "600000"; // 10 mins.
+  private static final String DEFAULT_DECLINE_OFFER_DURATION = "600"; // 10 mins.
   public static final double SHORT_DECLINE_OFFER_DURATION_SEC = 5;
   private String nativeLibraryPath;
   private String master;
@@ -724,10 +724,10 @@ public void setJenkinsURL(String jenkinsURL) {
         this.declineOfferDuration = DEFAULT_DECLINE_OFFER_DURATION;
       } else {
         double duration = Double.parseDouble(declineOfferDuration);
-        if (duration >= 1000) {
+        if (duration >= 1) {
           this.declineOfferDuration = declineOfferDuration;
         } else {
-          LOGGER.warning("Minimum declineOfferDuration (1000) > " + declineOfferDuration
+          LOGGER.warning("Minimum declineOfferDuration (1) > " + declineOfferDuration
               + ". Using default " + DEFAULT_DECLINE_OFFER_DURATION + " ms.");
           this.declineOfferDuration = DEFAULT_DECLINE_OFFER_DURATION;
         }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -391,15 +391,14 @@ public class MesosCloud extends Cloud {
   public StandardUsernamePasswordCredentials getCredentials() {
     if (credentialsId == null) {
       return null;
-    } else {
-      List<DomainRequirement> domainRequirements = (master == null) ? Collections.<DomainRequirement>emptyList()
-              : URIRequirementBuilder.fromUri(master.trim()).build();
-      Jenkins jenkins = getJenkins();
-      return CredentialsMatchers.firstOrNull(CredentialsProvider
-                      .lookupCredentials(StandardUsernamePasswordCredentials.class, jenkins, ACL.SYSTEM, domainRequirements),
-              CredentialsMatchers.withId(credentialsId)
-      );
     }
+    List<DomainRequirement> domainRequirements = (master == null) ? Collections.<DomainRequirement>emptyList()
+            : URIRequirementBuilder.fromUri(master.trim()).build();
+    Jenkins jenkins = getJenkins();
+    return CredentialsMatchers.firstOrNull(CredentialsProvider
+                    .lookupCredentials(StandardUsernamePasswordCredentials.class, jenkins, ACL.SYSTEM, domainRequirements),
+            CredentialsMatchers.withId(credentialsId)
+    );
   }
 
   private String getMetricName(Label label, String method, String metric) {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
@@ -52,12 +52,11 @@ public class MesosRetentionStrategy extends RetentionStrategy<MesosComputer> {
   public long check(MesosComputer c) {
     if (!computerCheckLock.tryLock()) {
       return 1;
-    } else {
-      try {
-        return checkInternal(c);
-      } finally {
-        computerCheckLock.unlock();
-      }
+    }
+    try {
+      return checkInternal(c);
+    } finally {
+      computerCheckLock.unlock();
     }
   }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosUtils.java
@@ -13,6 +13,9 @@ public final class MesosUtils {
         } else {
             suffix = StringUtils.remove("-" + label, " ");
         }
-        return StringUtils.left("mesos-jenkins-" + StringUtils.remove(UUID.randomUUID().toString(), '-') + suffix, MAX_HOSTNAME_LENGTH);
+        return StringUtils.left(
+            "mesos-jenkins-" +
+            StringUtils.left(StringUtils.remove(UUID.randomUUID().toString(), '-'), 8) +
+            suffix, MAX_HOSTNAME_LENGTH);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/OfferQueue.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/OfferQueue.java
@@ -22,7 +22,7 @@ public class OfferQueue {
     private final Logger logger = Logger.getLogger(JenkinsScheduler.class.getName());
 
     private static final int DEFAULT_CAPACITY = 100;
-    private static final Duration DEFAULT_OFFER_WAIT = Duration.ofSeconds(30);
+    private static final Duration DEFAULT_OFFER_WAIT = Duration.ofSeconds(600);
     private final BlockingQueue<Protos.Offer> queue;
 
     public OfferQueue() {

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -58,8 +58,8 @@
             <st:nbsp/>${%No}
         </f:entry>
 
-        <f:entry title="${%Decline offer duration}" field="declineOfferDuration" description="${%Decline offers for specified amount of time in case no slave is queued. The plugin asks for new offers in case a new slave needs to be started. In milliseconds.}">
-          <f:number clazz="required positive-number" min="1000" steps="1000" default="600000"/>
+        <f:entry title="${%Decline offer duration}" field="declineOfferDuration" description="${%Decline offers for specified amount of time in case no slave is queued. The plugin asks for new offers in case a new slave needs to be started. In seconds.}">
+          <f:number clazz="required positive-number" min="1" steps="1" default="600"/>
         </f:entry>
 
         <f:entry>


### PR DESCRIPTION
As a heavy user of jenkins mesos framework, I found this plugin become very unstable since v0.17 because of the new multi-threading model. If I enable 'On-demand framework registration', the jenkins framework will crash from time to time and freeze all mesos offers. With bug reported but no response for months, I have to create my own fork and fix on it. Now I'm happy to see v0.18.2 is in plan and hopefully my fixes would help a little.

Key changes:
* fix for #328, now it's safe to enable 'On-demand framework registration'
* make sure any received offer is answered so the offered resource won't be frozen
* fix concurrent read/write on requests queue, which drastically improved the stability

Other changes:
* fix for #334, providing a correct description and implementation for parameter 'Decline offer duration'
* shorten node id to improve the readability of computer names
* add a one-click build script 'dkbd.sh' powered by docker-compose
* a few style adjustments
