### PR TITLE
Support container images with mesos containerizer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ By default, the Jenkins slaves are run in the default Mesos container. To run th
 
 	2) "Use External Containerizer" : Select this option if Mesos slave(s) are configured with "--containerizers=external".
 
+To run jenkins slave within a docker image (but using mesos containerizer), use "Mesos" container type.
+
 ### Docker Configuration ###
 
 #### Volumes ####

--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
     <jenkins.version>2.7.3</jenkins.version>
     <java.level>8</java.level>
     <findbugs.failOnError>false</findbugs.failOnError>
-    <mesos.version>1.0.0</mesos.version>
-    <protobuf.version>2.6.1</protobuf.version>
+    <mesos.version>1.7.0</mesos.version>
+    <protobuf.version>3.5.0</protobuf.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.6</powermock.version>
     <assertj.version>2.1.0</assertj.version>

--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -19,6 +19,9 @@ package org.jenkinsci.plugins.mesos;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import com.google.protobuf.UnknownFieldSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Computer;
 import hudson.model.Node;
@@ -898,6 +901,16 @@ public class JenkinsScheduler implements Scheduler {
 
                 containerInfoBuilder.setDocker(dockerInfoBuilder);
                 break;
+            case MESOS:
+                LOGGER.info("Launching in Mesos Mode:" + containerInfo.getDockerImage());
+                ContainerInfo.MesosInfo.Builder mesosInfoBuilder = ContainerInfo.MesosInfo.newBuilder();
+                Image.Builder imageBuilder = Image.newBuilder().
+                        setType(Image.Type.DOCKER).
+                        setDocker(Image.Docker.newBuilder().setName(containerInfo.getDockerImage()));
+                mesosInfoBuilder.setImage(imageBuilder);
+                containerInfoBuilder.setMesos(mesosInfoBuilder);
+                break;
+
             default:
                 LOGGER.warning("Unknown container type:" + containerInfo.getType());
         }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCleanupThread.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCleanupThread.java
@@ -108,7 +108,7 @@ public class MesosCleanupThread extends AsyncPeriodicWork {
                             " is not pending deletion or the slave is null");
                 }
             } else {
-                logger.log(Level.FINER, c.getName() + " is not a mesos computer, it is a " + c.getClass().getName());
+              logger.log(Level.FINER, c.getName() + " is not a mesos computer, it is a " + c.getClass().getName());
             }
         }
 

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/ContainerInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/ContainerInfo/config.jelly
@@ -1,10 +1,10 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry title="${%Container Type}" field="type">
-        <f:radioBlock name="type" title="${%Docker}" value="DOCKER" inline="true" checked="true">
-            <f:entry title="${%Docker Image}" field="dockerImage" description="If using Docker, specify the docker image.">
+            <f:entry title="${%Docker Image}" field="dockerImage" description="Specify the docker image.">
                 <f:textbox clazz="required"/>
             </f:entry>
+        <f:radioBlock name="type" title="${%Docker}" value="DOCKER" inline="true" checked="false">
             <f:entry title="${%Docker Privileged Mode}" field="dockerPrivilegedMode" description="This will start the image using Docker's privileged mode.">
                 <f:checkbox/>
             </f:entry>
@@ -14,6 +14,8 @@
             <f:entry title="${%Docker Image Can Be Customized}" field="dockerImageCustomizable" description="This will allow override default docker image using labels. E.g.: mesosSlaveLabel:evarga/jenkins-slave:latest">
                 <f:checkbox/>
             </f:entry>
+        </f:radioBlock>
+        <f:radioBlock name="type" title="${%Mesos}" value="MESOS" inline="true" checked="false">
         </f:radioBlock>
     </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosSlaveInfo/config.jelly
@@ -68,7 +68,7 @@
     </f:entry>
 
     <f:advanced>
-        <f:optionalProperty title="${%Use Docker Containerizer}" field="containerInfo"/>
+        <f:optionalProperty title="${%Configure Containerizer}" field="containerInfo"/>
         <f:entry title="${%Additional URIs}">
             <f:repeatableProperty field="additionalURIs" minimum="0" add="Add URI">
                 <f:entry>


### PR DESCRIPTION
This PR introduces support to launch jenkins slave with mesos containerizer within a docker image.
This allows to benefit from mesos containerizer while getting filesystem isolation.

This is my first jenkins plugin patch and I would really appreciate feedback/advices (on jelly files especially).

PR also build against latest mesos version although it is not strictly necessary (I can remove this commit if needed)