### PR TITLE
change timeunit for decline-offer-duration parameter in config.jelly from ms to seconds

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -58,8 +58,8 @@
             <st:nbsp/>${%No}
         </f:entry>
 
-        <f:entry title="${%Decline offer duration}" field="declineOfferDuration" description="${%Decline offers for specified amount of time in case no slave is queued. The plugin asks for new offers in case a new slave needs to be started. In milliseconds.}">
-          <f:number clazz="required positive-number" min="1000" steps="1000" default="600000"/>
+        <f:entry title="${%Decline offer duration}" field="declineOfferDuration" description="${%Decline offers for specified amount of time in case no slave is queued. The plugin asks for new offers in case a new slave needs to be started. In seconds.}">
+          <f:number clazz="required positive-number" min="1" steps="1" default="600"/>
         </f:entry>
 
         <f:entry>


### PR DESCRIPTION
This is a fix for:
https://github.com/jenkinsci/mesos-plugin/issues/334

Renamed ms (milliseconds) to s (seconds), and divided number parameters by 1000.

The values from the config.jelly get passed to org.apache.mesos.Protos.Filters.Builder#setRefuseSeconds in org.jenkinsci.plugins.mesos.JenkinsScheduler#declineOffer, this method accepts seconds.

