### PR TITLE
Added offer suppression support.

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -183,6 +183,7 @@ public class JenkinsSchedulerTest {
         jenkinsScheduler.resourceOffers(driver, offers);
         Mockito.verify(driver, Mockito.never()).declineOffer(offer.getId());
         Mockito.verify(driver).declineOffer(offer.getId(), Protos.Filters.newBuilder().setRefuseSeconds(120000).build());
+        Mockito.verify(driver).suppressOffers();
     }
 
     @Test
@@ -200,6 +201,7 @@ public class JenkinsSchedulerTest {
         jenkinsScheduler.resourceOffers(driver, offers);
         Mockito.verify(driver).declineOffer(offer.getId(), Protos.Filters.newBuilder().setRefuseSeconds(MesosCloud.SHORT_DECLINE_OFFER_DURATION_SEC).build());
         Mockito.verify(driver, Mockito.never()).declineOffer(offer.getId(), Protos.Filters.newBuilder().setRefuseSeconds(120000).build());
+        Mockito.verify(driver, Mockito.never()).suppressOffers();
     }
 
     @Test
@@ -222,6 +224,7 @@ public class JenkinsSchedulerTest {
         jenkinsScheduler.resourceOffers(driver, offers);
         Mockito.verify(driver).declineOffer(offer.getId(), Protos.Filters.newBuilder().setRefuseSeconds(MesosCloud.SHORT_DECLINE_OFFER_DURATION_SEC).build());
         Mockito.verify(driver, Mockito.never()).declineOffer(offer.getId(), Protos.Filters.newBuilder().setRefuseSeconds(120000).build());
+        Mockito.verify(driver, Mockito.never()).suppressOffers();
     }
 
     @Test
@@ -419,6 +422,9 @@ public class JenkinsSchedulerTest {
 
     @Test
     public void constructMultiThreaded() {
+        Queue queue = Mockito.mock(Queue.class);
+        Mockito.when(jenkins.getQueue()).thenReturn(queue);
+
         SchedulerDriver driver = Mockito.mock(SchedulerDriver.class);
 
         jenkinsScheduler = new JenkinsScheduler("jenkinsMaster", mesosCloud, true);

--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -344,6 +344,28 @@ public class JenkinsSchedulerTest {
     }
 
     @Test
+    public void testReviveOffersAfterSuppressOffers() throws Exception {
+        Protos.Offer offer = createOfferWithVariableRanges(31000, 32000);
+        ArrayList<Protos.Offer> offers = new ArrayList<Protos.Offer>();
+        offers.add(offer);
+
+        Queue queue = Mockito.mock(Queue.class);
+        Mockito.when(jenkins.getQueue()).thenReturn(queue);
+
+        SchedulerDriver driver = Mockito.mock(SchedulerDriver.class);
+        jenkinsScheduler.setDriver(driver);
+        Mockito.when(mesosCloud.getDeclineOfferDurationDouble()).thenReturn((double) 120000);
+        jenkinsScheduler.resourceOffers(driver, offers);
+        Mockito.verify(driver, Mockito.never()).declineOffer(offer.getId());
+        Mockito.verify(driver).declineOffer(offer.getId(), Protos.Filters.newBuilder().setRefuseSeconds(120000).build());
+        Mockito.verify(driver).suppressOffers();
+
+        Mesos.SlaveRequest request = mockSlaveRequest(false, false, null);
+        jenkinsScheduler.requestJenkinsSlave(request, null);
+        Mockito.verify(driver).reviveOffers();
+    }
+
+    @Test
     public void testConstructMesosCommandInfoWithNoContainer() throws Exception {
         JenkinsScheduler.Request request = mockMesosRequest(Boolean.FALSE, null, null);
 


### PR DESCRIPTION
Offers are suppressed when there is no pending work and revived when there is. The code guards against the cases that either suppress (by calling on subsequent offer reception) or revived (by calling it periodically) are dropped.