### PR TITLE
Add Single Use property to MesosSlave (#16)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosRetentionStrategy.java
@@ -73,6 +73,13 @@ public class MesosRetentionStrategy extends RetentionStrategy<MesosComputer> {
       return 1;
     }
 
+    // Terminate if the computer is idle and a single-use agent.
+    if (c.isIdle() && c.isOffline() && node.isSingleUse()) {
+      LOGGER.info("Disconnecting single-use computer " + c.getName());
+      node.setPendingDelete(true);
+      return 1;
+    }
+
     // If we just launched this computer, check back after 1 min.
     // NOTE: 'c.getConnectTime()' refers to when the Jenkins slave was launched.
     if ((DateTimeUtils.currentTimeMillis() - c.getConnectTime()) <

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSingleUseSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSingleUseSlave.java
@@ -57,6 +57,22 @@ public class MesosSingleUseSlave extends SimpleBuildWrapper {
     @Override
     public void setUp(Context context, Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
         context.setDisposer(new MesosSingleUseSlaveDisposer());
+
+        Computer computer = workspace.toComputer();
+        if (computer != null) {
+            if (MesosComputer.class.isInstance(computer)) {
+                String msg = "Marking " + computer.getName() + " as single-use.";
+                LOGGER.warning(msg);
+                listener.getLogger().println(msg);
+
+                MesosSlave mesosSlave = (MesosSlave) computer.getNode();
+                if (mesosSlave != null) {
+                    mesosSlave.setSingleUse(true);
+                }
+            } else {
+                listener.getLogger().println("Not able to set single-use slave, this is a " + computer.getClass());
+            }
+        }
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSingleUseSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSingleUseSlave.java
@@ -62,7 +62,7 @@ public class MesosSingleUseSlave extends SimpleBuildWrapper {
         if (computer != null) {
             if (MesosComputer.class.isInstance(computer)) {
                 String msg = "Marking " + computer.getName() + " as single-use.";
-                LOGGER.warning(msg);
+                LOGGER.info(msg);
                 listener.getLogger().println(msg);
 
                 MesosSlave mesosSlave = (MesosSlave) computer.getNode();


### PR DESCRIPTION
* Add Single Use property to MesosSlave

Single-use agents are marked offline and then still wait for
idle timeout before being deleted. This commit adds a new
property to MesosSlave to mark single-use agents. This is
read during the retention check and used to mark a cluster
for deletion.

* Order matters

* Add locks around new property

* Add test for single use and retention policy

* Sync pending delete as well