### PR TITLE
Suppress/long decline should not directly look at pending builds.

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/JenkinsSchedulerTest.java
@@ -205,7 +205,7 @@ public class JenkinsSchedulerTest {
     }
 
     @Test
-    public void testDeclineOffersWithBuildsInQueue() throws Exception {
+    public void testDeclineOffersWithBuildsInQueueButNoRequestsinQueue() throws Exception {
         Protos.Offer offer = createOfferWithVariableRanges(31000, 32000);
         ArrayList<Protos.Offer> offers = new ArrayList<Protos.Offer>();
         offers.add(offer);
@@ -222,9 +222,9 @@ public class JenkinsSchedulerTest {
         jenkinsScheduler.setDriver(driver);
         Mockito.when(mesosCloud.getDeclineOfferDurationDouble()).thenReturn((double) 120000);
         jenkinsScheduler.resourceOffers(driver, offers);
-        Mockito.verify(driver).declineOffer(offer.getId(), Protos.Filters.newBuilder().setRefuseSeconds(MesosCloud.SHORT_DECLINE_OFFER_DURATION_SEC).build());
-        Mockito.verify(driver, Mockito.never()).declineOffer(offer.getId(), Protos.Filters.newBuilder().setRefuseSeconds(120000).build());
-        Mockito.verify(driver, Mockito.never()).suppressOffers();
+        Mockito.verify(driver, Mockito.never()).declineOffer(offer.getId());
+        Mockito.verify(driver).declineOffer(offer.getId(), Protos.Filters.newBuilder().setRefuseSeconds(120000).build());
+        Mockito.verify(driver).suppressOffers();
     }
 
     @Test


### PR DESCRIPTION
Pending builds might be enqueued on the already connected executors, so
the scheduler shouldn't be waiting for offers for those. Offers are only
relevant when the node provisioner enques a slave provision request on
to the scheduler.