### PR TITLE
Fix incorrect duration of DEFAULT_DECLINE_OFFER_DURATION

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -61,8 +61,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class MesosCloud extends Cloud {
-  private static final String DEFAULT_DECLINE_OFFER_DURATION = "600000"; // 10 mins.
-  public static final double SHORT_DECLINE_OFFER_DURATION_SEC = 5;
+  private static final String DEFAULT_DECLINE_OFFER_DURATION = "600"; // 10 mins.
+  public static final double SHORT_DECLINE_OFFER_DURATION_SEC = 5; //5 seconds
   private String nativeLibraryPath;
   private String master;
   private String description;
@@ -726,7 +726,7 @@ public void setJenkinsURL(String jenkinsURL) {
   public void setDeclineOfferDuration(String declineOfferDuration) {
     try {
       if (declineOfferDuration == null) {
-        LOGGER.fine("Missing declineOfferDuration. Using default " + DEFAULT_DECLINE_OFFER_DURATION + " ms.");
+        LOGGER.fine("Missing declineOfferDuration. Using default " + DEFAULT_DECLINE_OFFER_DURATION + " s.");
         this.declineOfferDuration = DEFAULT_DECLINE_OFFER_DURATION;
       } else {
         double duration = Double.parseDouble(declineOfferDuration);
@@ -734,13 +734,13 @@ public void setJenkinsURL(String jenkinsURL) {
           this.declineOfferDuration = declineOfferDuration;
         } else {
           LOGGER.warning("Minimum declineOfferDuration (1000) > " + declineOfferDuration
-              + ". Using default " + DEFAULT_DECLINE_OFFER_DURATION + " ms.");
+              + ". Using default " + DEFAULT_DECLINE_OFFER_DURATION + " s.");
           this.declineOfferDuration = DEFAULT_DECLINE_OFFER_DURATION;
         }
       }
     } catch (NumberFormatException e) {
       LOGGER.warning("Unable to parse declineOfferDuration: " + declineOfferDuration
-          + ". Using default " + DEFAULT_DECLINE_OFFER_DURATION + " ms.");
+          + ". Using default " + DEFAULT_DECLINE_OFFER_DURATION + " s.");
       this.declineOfferDuration = DEFAULT_DECLINE_OFFER_DURATION;
     }
   }

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -58,8 +58,8 @@
             <st:nbsp/>${%No}
         </f:entry>
 
-        <f:entry title="${%Decline offer duration}" field="declineOfferDuration" description="${%Decline offers for specified amount of time in case no slave is queued. The plugin asks for new offers in case a new slave needs to be started. In milliseconds.}">
-          <f:number clazz="required positive-number" min="1000" steps="1000" default="600000"/>
+        <f:entry title="${%Decline offer duration}" field="declineOfferDuration" description="${%Decline offers for specified amount of time in case no slave is queued. The plugin asks for new offers in case a new slave needs to be started. In seconds.}">
+          <f:number clazz="required positive-number" min="100" steps="100" default="600"/>
         </f:entry>
 
         <f:entry>


### PR DESCRIPTION
Duration was incorrectly interpeted as 600000 seconds which isn't what the original author intended.
Reset all decline durations to be in seconds to avoid this confusion in the future.