### PR TITLE
Update build badge link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href='https://jenkins.mesosphere.com/service/jenkins/job/Mesos%20Jenkins%20Plugin/mesos-plugin/master'><img src='https://jenkins.mesosphere.com/service/jenkins/buildStatus/icon?job=Mesos%20Jenkins%20Plugin/mesos-plugin/master'></a>
+  <a href='https://ci.jenkins.io/job/Plugins/job/mesos-plugin/job/master/'><img src='https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Fmesos-plugin%2Fmaster'></a>
   <a href="https://cloud.docker.com/u/mesosphere/repository/docker/mesosphere/jenkins/general"><img alt="Docker Pulls" src="https://img.shields.io/docker/pulls/mesosphere/jenkins.svg"></a>
 </p>
 


### PR DESCRIPTION
Let's use the official ci.jenkins.io build status.