### PR TITLE
Replace invalid hostname characters for task names and docker hostname

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosUtils.java
@@ -5,13 +5,22 @@ import java.util.UUID;
 
 public final class MesosUtils {
     private static final int MAX_HOSTNAME_LENGTH = 63; // Guard against LONG hostnames - RFC-1034
+    /** The buildNodeName may contain the jenkins label, and is subsequently
+     * used to name the mesos task and docker hostname.
+     * A mesos task cannot contain "/"
+     * A docker hostname may not contain ":" or "/"
+     * Even if jenkins can accept those characters for the build node name,
+     * we clean it up here for consistency
+     * https://github.com/jenkinsci/mesos-plugin/issues/251
+     */
+    private static final String REPLACE_INVALID_CHARS = "[^a-zA-Z0-9-]"; // RFC 952
 
     public static String buildNodeName(String label) {
         String suffix;
         if (label == null) {
             suffix = StringUtils.EMPTY;
         } else {
-            suffix = StringUtils.remove("-" + label, " ");
+            suffix = "-" + label.replaceAll(REPLACE_INVALID_CHARS, "-");
         }
         return StringUtils.left("mesos-jenkins-" + StringUtils.remove(UUID.randomUUID().toString(), '-') + suffix, MAX_HOSTNAME_LENGTH);
     }

--- a/src/test/java/org/jenkinsci/plugins/mesos/MesosUtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/MesosUtilsTest.java
@@ -17,4 +17,13 @@ public class MesosUtilsTest {
         assertTrue(nodeName.length() <= 63);
         assertFalse(nodeName.contains(" "));
     }
+
+    //https://github.com/jenkinsci/mesos-plugin/issues/251
+    @Test
+    public void nodeNameShouldntHaveInvalidChars() {
+        String nodeName = MesosUtils.buildNodeName("similar/to:dockertags");
+        assertTrue(nodeName.length() <= 63);
+        assertFalse(nodeName.contains("/"));
+        assertFalse(nodeName.contains(":"));
+    }
 }


### PR DESCRIPTION
Before this change, if you used the mesos plugin option 'Docker Image Can Be Customized'
and the resulting task name was less than 64 characters it could happen that the docker
image name contained invalid characters both for the task name and the docker hostname.
For example a custom label:foo/bar:latest would fail as a task name because / is invalid
in a task name since it breaks the directory structure. It would also fail as a docker
hostname since it needs to comply with RFC 1123 hostnames

Original commit was to fix #251
Making the change to the buildNodeName() makes it consistent across the code