### PR TITLE
Define agent shell command style.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
@@ -315,27 +315,6 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
         load();
       }
     }
-
-    /**
-     * Migrate older fields from 0.x and 1.x of the plugin.
-     *
-     * @return The migrated container info.
-     */
-    private Object readResolve() {
-
-      // No custom shell command should be used the shell command field must be null.
-      if (!this.useCustomDockerCommandShell) {
-        return new ContainerInfo(
-            this.type,
-            this.dockerImage,
-            this.isDind,
-            this.dockerPrivilegedMode,
-            this.dockerForcePullImage,
-            this.volumes);
-      } else {
-        return this;
-      }
-    }
   }
 
   public static class Volume extends AbstractDescribableImpl<Volume> {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
@@ -48,6 +48,7 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
   private final int maxExecutors;
   private final String jnlpArgs;
   private final List<MesosSlaveInfo.URI> additionalURIs;
+  private final LaunchCommandBuilder.AgentCommandStyle agentCommandStyle;
   private final ContainerInfo containerInfo;
   private final DomainFilterImpl domainInfoFilter;
 
@@ -64,6 +65,7 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
       String jnlpArgs,
       List<MesosSlaveInfo.URI> additionalURIs,
       ContainerInfo containerInfo,
+      LaunchCommandBuilder.AgentCommandStyle agentCommandStyle,
       DomainFilterImpl domainInfoFilter) {
     this.label = label;
     this.labelSet = Label.parse(label);
@@ -79,6 +81,7 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
     this.additionalURIs = (additionalURIs != null) ? additionalURIs : Collections.emptyList();
     this.containerInfo = containerInfo;
     this.domainInfoFilter = domainInfoFilter;
+    this.agentCommandStyle = agentCommandStyle;
     validate();
   }
 
@@ -149,6 +152,7 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
         .withContainerInfo(Optional.ofNullable(this.getContainerInfo()))
         .withDomainInfoFilter(Optional.ofNullable(this.getDomainInfoFilter()))
         .withJnlpArguments(this.getJnlpArgs())
+        .withAgentCommandStyle(Optional.ofNullable(this.agentCommandStyle))
         .withAdditionalFetchUris(fetchUris)
         .build();
   }
@@ -206,6 +210,10 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
     return maxExecutors;
   }
 
+  public LaunchCommandBuilder.AgentCommandStyle getAgentCommandStyle() {
+    return this.agentCommandStyle;
+  }
+
   public String getJnlpArgs() {
     return jnlpArgs;
   }
@@ -225,7 +233,6 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
     private final List<Volume> volumes;
     private final boolean dockerPrivilegedMode;
     private final boolean dockerForcePullImage;
-    private final String customDockerCommandShell;
     private boolean isDind;
 
     @SuppressFBWarnings("UUF_UNUSED_FIELD")
@@ -246,11 +253,13 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
     @SuppressFBWarnings("UUF_UNUSED_FIELD")
     private transient boolean useCustomDockerCommandShell;
 
+    @SuppressFBWarnings("UUF_UNUSED_FIELD")
+    private transient String customDockerCommandShell;
+
     @DataBoundConstructor
     public ContainerInfo(
         String type,
         String dockerImage,
-        String customDockerCommandShell,
         boolean isDind,
         boolean dockerPrivilegedMode,
         boolean dockerForcePullImage,
@@ -262,10 +271,6 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
       this.volumes = volumes;
       this.customDockerCommandShell = customDockerCommandShell;
       this.isDind = isDind;
-    }
-
-    public String getCustomDockerCommandShell() {
-      return this.customDockerCommandShell;
     }
 
     public boolean getIsDind() {
@@ -316,7 +321,6 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
         return new ContainerInfo(
             this.type,
             this.dockerImage,
-            null,
             this.isDind,
             this.dockerPrivilegedMode,
             this.dockerForcePullImage,

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
@@ -225,6 +225,7 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
     private final List<Volume> volumes;
     private final boolean dockerPrivilegedMode;
     private final boolean dockerForcePullImage;
+    private final String customDockerCommandShell;
     private boolean isDind;
 
     @SuppressFBWarnings("UUF_UNUSED_FIELD")
@@ -245,13 +246,11 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
     @SuppressFBWarnings("UUF_UNUSED_FIELD")
     private transient boolean useCustomDockerCommandShell;
 
-    @SuppressFBWarnings("UUF_UNUSED_FIELD")
-    private transient String customDockerCommandShell;
-
     @DataBoundConstructor
     public ContainerInfo(
         String type,
         String dockerImage,
+        String customDockerCommandShell,
         boolean isDind,
         boolean dockerPrivilegedMode,
         boolean dockerForcePullImage,
@@ -261,7 +260,12 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
       this.dockerPrivilegedMode = dockerPrivilegedMode;
       this.dockerForcePullImage = dockerForcePullImage;
       this.volumes = volumes;
+      this.customDockerCommandShell = customDockerCommandShell;
       this.isDind = isDind;
+    }
+
+    public String getCustomDockerCommandShell() {
+      return this.customDockerCommandShell;
     }
 
     public boolean getIsDind() {
@@ -297,6 +301,28 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
 
       public DescriptorImpl() {
         load();
+      }
+    }
+
+    /**
+     * Migrate older fields from 0.x and 1.x of the plugin.
+     *
+     * @return The migrated container info.
+     */
+    private Object readResolve() {
+
+      // No custom shell command should be used the shell command field must be null.
+      if (!this.useCustomDockerCommandShell) {
+        return new ContainerInfo(
+            this.type,
+            this.dockerImage,
+            null,
+            this.isDind,
+            this.dockerPrivilegedMode,
+            this.dockerForcePullImage,
+            this.volumes);
+      } else {
+        return this;
       }
     }
   }

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -70,6 +70,7 @@ public class MesosSlaveInfo {
         this.jnlpArgs,
         this.additionalURIs,
         this.containerInfo,
+        null,
         null);
   }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/LaunchCommandBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/LaunchCommandBuilder.java
@@ -37,7 +37,7 @@ public class LaunchCommandBuilder {
   // We allocate extra memory for the JVM
   private static final int JVM_XMX = 32;
 
-  public enum AgentCommandStyle {
+  public static enum AgentCommandStyle {
     Linux,
     Windows
   }
@@ -157,6 +157,9 @@ public class LaunchCommandBuilder {
         break;
       case Windows:
         template = WINDOWS_AGENT_COMMAND_TEMPLATE;
+        break;
+      default:
+        template = LINUX_AGENT_COMMAND_TEMPLATE;
         break;
     }
     return String.format(

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/LaunchCommandBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/LaunchCommandBuilder.java
@@ -48,7 +48,7 @@ public class LaunchCommandBuilder {
   private static final String LINUX_AGENT_COMMAND_TEMPLATE =
       "java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar ${MESOS_SANDBOX-.}/agent.jar %s %s -jnlpUrl %s";
   private static final String WINDOWS_AGENT_COMMAND_TEMPLATE =
-      "java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar %MESOS_SANDBOX%/agent.jar %s %s -jnlpUrl %s";
+      "java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar %%MESOS_SANDBOX%%/agent.jar %s %s -jnlpUrl %s";
 
   private static final String JNLP_SECRET_FORMAT = "-secret %s";
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/LaunchCommandBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/LaunchCommandBuilder.java
@@ -137,13 +137,19 @@ public class LaunchCommandBuilder {
 
   /** @return the agent shell command for the Mesos task. */
   private String buildCommand() throws MalformedURLException {
-    return String.format(
-        AGENT_COMMAND_FORMAT,
-        this.xmx,
-        this.jvmArgString,
-        this.jnlpArgString,
-        buildJnlpSecret(),
-        buildJnlpUrl());
+    // Check if command is overriden
+    if (this.containerInfo.isPresent()
+        && this.containerInfo.get().getCustomDockerCommandShell() != null) {
+      return this.containerInfo.get().getCustomDockerCommandShell();
+    } else {
+      return String.format(
+          AGENT_COMMAND_FORMAT,
+          this.xmx,
+          this.jvmArgString,
+          this.jnlpArgString,
+          buildJnlpSecret(),
+          buildJnlpUrl());
+    }
   }
 
   @VisibleForTesting

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/ContainerInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/ContainerInfo/config.jelly
@@ -15,6 +15,16 @@
         <f:radioBlock name="type" title="${%Mesos}" value="MESOS" inline="true" checked="${instance.type == 'MESOS'}"></f:radioBlock>
     </f:entry>
 
+    <f:block>
+      <table>
+      <f:optionalBlock name="overrideShellCommand" title="${%Override Default Shell Command}">
+        <f:entry title="Shell Command" field="customDockerCommandShell">
+            <f:textbox clazz="required"/>
+        </f:entry>
+      </f:optionalBlock>
+      </table>
+    </f:block>
+
     <f:entry title="${%Docker in Docker image}" field="isDind" >
         <f:checkbox/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/ContainerInfo/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/ContainerInfo/config.jelly
@@ -15,16 +15,6 @@
         <f:radioBlock name="type" title="${%Mesos}" value="MESOS" inline="true" checked="${instance.type == 'MESOS'}"></f:radioBlock>
     </f:entry>
 
-    <f:block>
-      <table>
-      <f:optionalBlock name="overrideShellCommand" title="${%Override Default Shell Command}">
-        <f:entry title="Shell Command" field="customDockerCommandShell">
-            <f:textbox clazz="required"/>
-        </f:entry>
-      </f:optionalBlock>
-      </table>
-    </f:block>
-
     <f:entry title="${%Docker in Docker image}" field="isDind" >
         <f:checkbox/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/ContainerInfo/help-overrideShellCommand.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/ContainerInfo/help-overrideShellCommand.html
@@ -1,7 +1,0 @@
-<div>
-  Check if you do not want to use the default command to launch the Jenkins agent. This is useful if
-  you want to start the agent in a Windows container:
-  <code>
-    java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar ${MESOS_SANDBOX-.}/agent.jar %s %s -jnlpUrl %s";
-  </code>
-</div>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/ContainerInfo/help-overrideShellCommand.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/ContainerInfo/help-overrideShellCommand.html
@@ -1,4 +1,7 @@
 <div>
   Check if you do not want to use the default command to launch the Jenkins agent. This is useful if
-  you want to start the agent in a Windows container.
+  you want to start the agent in a Windows container:
+  <code>
+    java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar ${MESOS_SANDBOX-.}/agent.jar %s %s -jnlpUrl %s";
+  </code>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/ContainerInfo/help-overrideShellCommand.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/ContainerInfo/help-overrideShellCommand.html
@@ -1,0 +1,4 @@
+<div>
+  Check if you do not want to use the default command to launch the Jenkins agent. This is useful if
+  you want to start the agent in a Windows container.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/config.jelly
@@ -41,7 +41,9 @@
          <f:optionalProperty title="${%Configure Containerizer}" field="containerInfo"/>
 
          <f:entry title="${%Agent Command Style}" field="agentCommandStyle">
-             <f:enum/>
+             <f:enum field="agentCommandStyle">
+               ${it.toString()}
+             </f:enum>
          </f:entry>
 
          <f:optionalProperty title="${%Filter Fault Domain}" field="domainInfoFilter"/>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/config.jelly
@@ -40,6 +40,10 @@
 
          <f:optionalProperty title="${%Configure Containerizer}" field="containerInfo"/>
 
+         <f:entry title="${%Agent Command Style}" field="agentCommandStyle">
+             <f:enum/>
+         </f:entry>
+
          <f:optionalProperty title="${%Filter Fault Domain}" field="domainInfoFilter"/>
 
           <f:entry title="${%Additional URIs}">

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/help-agentCommandStyle.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/help-agentCommandStyle.html
@@ -1,0 +1,5 @@
+<div>
+  Defines the style of the command used to launch a Jenkins agent on Mesos. It defaults to Linux but
+  also supports Windows. The launch commands differ because Windows use <code>%ENV_VAR%</code> while
+  Unix based systems use <code>${ENV_VAR}</code>.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
@@ -42,6 +42,7 @@ public class AgentSpecMother {
           new ContainerInfo(
               "DOCKER",
               "mesosphere/jenkins-dind:0.6.0-alpine",
+              null,
               true,
               true,
               false,


### PR DESCRIPTION
Summary:
When the Jenkins agent is launched on a Windows node the command differs slightly
from the Linux command. This patch introduces a command style which defaults to Linux.