### PR TITLE
Configure Linux and Windows agents.

### DIFF
--- a/dcos/conf/jenkins/configuration.yaml
+++ b/dcos/conf/jenkins/configuration.yaml
@@ -9,15 +9,41 @@ jenkins:
         frameworkName: "${JENKINS_FRAMEWORK_NAME:-Jenkins Scheduler}"
         jenkinsUrl: "http://${JENKINS_FRAMEWORK_NAME:-jenkins}.${MARATHON_NAME:-marathon}.mesos:${PORT0:-8080}"
         mesosAgentSpecTemplates:
-          - containerImage: "amazoncorretto:8"
-            cpus: "0.1"
-            defaultAgent: false
-            disk: "0.0"
-            executorMem: 128
+          - label: "linux"
+            agentAttributes: ""
+            agentCommandStyle: Linux
+            containerInfo:
+              dockerForcePullImage: false
+              dockerImage: "amazoncorretto:8"
+              dockerPrivilegedMode: false
+              isDind: false
+              networking: HOST
+              type: "DOCKER"
+            cpus: 0.1
+            disk: 0.0
+            domainFilterModel: "home"
             idleTerminationMinutes: 3
             jnlpArgs: "-noReconnect"
             jvmArgs: "-Xms16m -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true"
-            label: "mesos"
+            maxExecutors: 1
+            mem: 512
+            minExecutors: 1
+            mode: NORMAL
+          - label: "windows"
+            agentAttributes: "os:windows"
+            agentCommandStyle: Windows
+            containerInfo:
+              dockerForcePullImage: false
+              dockerImage: "winamd64/openjdk:8-jre-windowsservercore-1809"
+              dockerPrivilegedMode: false
+              isDind: false
+              networking: BRIDGE
+              type: "DOCKER"
+            cpus: 0.1
+            disk: 0.0
+            domainFilterModel: "any"
+            idleTerminationMinutes: 3
+            jnlpArgs: "-noReconnect"
             maxExecutors: 1
             mem: 512
             minExecutors: 1


### PR DESCRIPTION
Summary:
This patch provides an example configuration for Linux and Windows
nodes.

Depends on #377.

JIRA issues: DCOS-61124