### PR TITLE
Reuse Mesos session.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ test {
 }
 
 group = "org.jenkins-ci.plugins"
-version = "2.0-beta-11"
+version = "2.0-beta-12"
 description = "Allows the dynamic launch of Jenkins agent on a Mesos cluster, depending on workload"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.28-9e5746a-SNAPSHOT'
+    usiVersion= '0.1.28-7b3e510-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ test {
 }
 
 group = "org.jenkins-ci.plugins"
-version = "2.0-beta-10"
+version = "2.0-beta-11"
 description = "Allows the dynamic launch of Jenkins agent on a Mesos cluster, depending on workload"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ test {
 }
 
 group = "org.jenkins-ci.plugins"
-version = "2.0-beta-9"
+version = "2.0-beta-10"
 description = "Allows the dynamic launch Jenkins agent on a Mesos cluster, depending on workload"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.28'
+    usiVersion= '0.1.28-06c3fe4-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.28-7b3e510-SNAPSHOT'
+    usiVersion= '0.1.29'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.28-4c188f8-SNAPSHOT'
+    usiVersion= '0.1.28-9e5746a-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.28-06c3fe4-SNAPSHOT'
+    usiVersion= '0.1.28-97eb25c-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ test {
 
 group = "org.jenkins-ci.plugins"
 version = "2.0-beta-10"
-description = "Allows the dynamic launch Jenkins agent on a Mesos cluster, depending on workload"
+description = "Allows the dynamic launch of Jenkins agent on a Mesos cluster, depending on workload"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.28-97eb25c-SNAPSHOT'
+    usiVersion= '0.1.28-4c188f8-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/dcos/conf/jenkins/configuration.yaml
+++ b/dcos/conf/jenkins/configuration.yaml
@@ -25,7 +25,7 @@ jenkins:
             idleTerminationMinutes: 3
             jnlpArgs: "-noReconnect"
             maxExecutors: 1
-            mem: 512
+            mem: "512"
             minExecutors: 1
             mode: EXCLUSIVE 
           - label: "windows"
@@ -44,7 +44,7 @@ jenkins:
             idleTerminationMinutes: 3
             jnlpArgs: "-noReconnect"
             maxExecutors: 1
-            mem: 4096 
+            mem: "4096"
             minExecutors: 1
             mode: EXCLUSIVE 
         mesosMasterUrl: "${JENKINS_MESOS_MASTER:-http://leader.mesos:5050}"

--- a/dcos/conf/plugins.conf
+++ b/dcos/conf/plugins.conf
@@ -18,6 +18,7 @@
   job-dsl:1.70                   
   jobConfigHistory:2.19          
   parameterized-trigger:2.35.2
+  pipeline:2.6
   plain-credentials:1.4
   rebuild:1.28                   
   role-strategy:2.9.0            

--- a/dcos/jenkins-app.json
+++ b/dcos/jenkins-app.json
@@ -8,6 +8,13 @@
   "acceptedResourceRoles": [
     "*"
   ],
+  "constraints": [
+    [
+      "os",
+      "UNLIKE",
+      "windows"
+    ]
+  ],
   "container": {
     "type": "DOCKER",
     "docker": {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -48,7 +48,7 @@ import scala.concurrent.ExecutionContext;
  * Provides a simplified interface to Mesos through USI.
  *
  * <p>Each connection should be a singleton. New instance are create via {@link
- * MesosApi#getInstance(String)}.
+ * MesosApi#getInstance(String, URL, String, String, String, String, Optional, Optional)}.
  */
 public class MesosApi {
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -127,8 +127,7 @@ public class MesosApi {
    * @throws InterruptedException
    * @throws ExecutionException
    */
-  @VisibleForTesting
-  private MesosApi(
+  public MesosApi(
       String master,
       URL jenkinsUrl,
       String agentUser,
@@ -234,8 +233,7 @@ public class MesosApi {
    * @param system The Akka actor system to use.
    * @param materializer The Akka stream materializer to use.
    */
-  @VisibleForTesting
-  private MesosApi(
+  public MesosApi(
       URL jenkinsUrl,
       String agentUser,
       String frameworkName,

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -293,6 +293,7 @@ public class MesosApi {
    * @return a {@link MesosJenkinsAgent} once it's queued for running.
    */
   public CompletionStage<Void> killAgent(PodId podId) {
+    logger.info("Kill agent {}.", podId.value());
     SchedulerCommand command = new KillPod(podId);
     return commands
         .offer(command)

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -365,8 +365,12 @@ public class MesosApi {
             .addRoles(role)
             .addCapabilities(
                 Protos.FrameworkInfo.Capability.newBuilder()
-                    .setType(Protos.FrameworkInfo.Capability.Type.MULTI_ROLE)
-                    .setType(Protos.FrameworkInfo.Capability.Type.REGION_AWARE)
+                    .setType(Protos.FrameworkInfo.Capability.Type.MULTI_ROLE))
+            .addCapabilities(
+                Protos.FrameworkInfo.Capability.newBuilder()
+                    .setType(Protos.FrameworkInfo.Capability.Type.REGION_AWARE))
+            .addCapabilities(
+                Protos.FrameworkInfo.Capability.newBuilder()
                     .setType(Protos.FrameworkInfo.Capability.Type.PARTITION_AWARE))
             .setFailoverTimeout(this.operationalSettings.getFailoverTimeout().getSeconds())
             .build();

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -365,7 +365,9 @@ public class MesosApi {
             .addRoles(role)
             .addCapabilities(
                 Protos.FrameworkInfo.Capability.newBuilder()
-                    .setType(Protos.FrameworkInfo.Capability.Type.MULTI_ROLE))
+                    .setType(Protos.FrameworkInfo.Capability.Type.MULTI_ROLE)
+                    .setType(Protos.FrameworkInfo.Capability.Type.REGION_AWARE)
+                    .setType(Protos.FrameworkInfo.Capability.Type.PARTITION_AWARE))
             .setFailoverTimeout(this.operationalSettings.getFailoverTimeout().getSeconds())
             .build();
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -6,7 +6,6 @@ import akka.stream.ActorMaterializer;
 import akka.stream.OverflowStrategy;
 import akka.stream.QueueOfferResult;
 import akka.stream.javadsl.*;
-import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.mesos.MasterDetector$;
 import com.mesosphere.mesos.client.CredentialsProvider;
 import com.mesosphere.mesos.client.DcosServiceAccountProvider;

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -102,6 +102,7 @@ public class MesosCloud extends AbstractCloudImpl {
   public MesosCloud(
       String mesosMasterUrl,
       String frameworkName,
+      String frameworkId,
       String role,
       String agentUser,
       String jenkinsURL,
@@ -131,12 +132,14 @@ public class MesosCloud extends AbstractCloudImpl {
     this.mesosAgentSpecTemplates = mesosAgentSpecTemplates;
     this.frameworkName = frameworkName;
 
-    if (this.frameworkId == null) {
+    this.frameworkId = frameworkId;
+    if (StringUtils.isEmpty(this.frameworkId)) {
+      logger.info("Framework ID was null.");
       this.frameworkId = UUID.randomUUID().toString();
     }
 
     this.mesosApi =
-        new MesosApi(
+        MesosApi.getInstance(
             this.master,
             this.jenkinsURL,
             this.agentUser,
@@ -145,7 +148,6 @@ public class MesosCloud extends AbstractCloudImpl {
             this.role,
             this.sslCert,
             this.dcosAuthorization);
-    logger.info("Initialized Mesos API object.");
   }
 
   private Object readResolve() throws IOException {
@@ -179,7 +181,7 @@ public class MesosCloud extends AbstractCloudImpl {
 
     try {
       this.mesosApi =
-          new MesosApi(
+          MesosApi.getInstance(
               this.master,
               this.jenkinsURL,
               this.agentUser,

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.mesos;
 import static java.lang.Math.toIntExact;
 
 import com.codahale.metrics.Timer;
-import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.mesos.MasterDetector$;
 import hudson.Extension;
 import hudson.model.Descriptor;
@@ -154,7 +153,7 @@ public class MesosCloud extends AbstractCloudImpl {
     // Migration from 1.x
     if (this.agentUser == null && this.slavesUser != null) {
       this.agentUser = this.slavesUser;
-    } else if (this.agentUser == null){
+    } else if (this.agentUser == null) {
       this.agentUser = "nobody";
     }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -134,7 +134,6 @@ public class MesosCloud extends AbstractCloudImpl {
 
     this.frameworkId = frameworkId;
     if (StringUtils.isEmpty(this.frameworkId)) {
-      logger.info("Framework ID was null.");
       this.frameworkId = UUID.randomUUID().toString();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.mesos;
 import static java.lang.Math.toIntExact;
 
 import com.codahale.metrics.Timer;
+import com.google.common.annotations.VisibleForTesting;
 import com.mesosphere.mesos.MasterDetector$;
 import hudson.Extension;
 import hudson.model.Descriptor;
@@ -153,7 +154,7 @@ public class MesosCloud extends AbstractCloudImpl {
     // Migration from 1.x
     if (this.agentUser == null && this.slavesUser != null) {
       this.agentUser = this.slavesUser;
-    } else {
+    } else if (this.agentUser == null){
       this.agentUser = "nobody";
     }
 
@@ -531,6 +532,10 @@ public class MesosCloud extends AbstractCloudImpl {
 
   public String getMesosMasterUrl() {
     return this.master;
+  }
+
+  public String getFrameworkId() {
+    return this.frameworkId;
   }
 
   public String getFrameworkName() {

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosProvisioningStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosProvisioningStrategy.java
@@ -66,7 +66,12 @@ public class MesosProvisioningStrategy extends NodeProvisioner.Strategy {
                 strategyState.recordPendingLaunches(plannedNodes);
                 availableCapacity += plannedNodes.size();
                 logger.info(
-                    "After provisioning, available capacity={}, currentDemand={}",
+                    "After provisioning, availableCapacity={}, currentDemand={}",
+                    availableCapacity,
+                    currentDemand);
+              } else {
+                logger.info(
+                    "No need to provision new nodes. availableCapacity={}, currentDemand={}",
                     availableCapacity,
                     currentDemand);
               }

--- a/src/main/java/org/jenkinsci/plugins/mesos/config/models/faultdomain/StringDomainFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/config/models/faultdomain/StringDomainFilter.java
@@ -22,6 +22,11 @@ public class StringDomainFilter extends DomainFilterModel implements DomainFilte
     return this;
   }
 
+  @Override
+  public String description() {
+    return String.format("accept %s region and %s zone", region, zone);
+  }
+
   /**
    * Application of the domain filter.
    *

--- a/src/main/java/org/jenkinsci/plugins/mesos/config/models/faultdomain/StringDomainFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/config/models/faultdomain/StringDomainFilter.java
@@ -47,4 +47,12 @@ public class StringDomainFilter extends DomainFilterModel implements DomainFilte
       return "String Matching";
     }
   }
+
+  public String getRegion() {
+    return this.region;
+  }
+
+  public String getZone() {
+    return this.zone;
+  }
 }

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosCloud/config.jelly
@@ -10,6 +10,10 @@
         <f:textbox default="Jenkins Scheduler" clazz="required"/>
     </f:entry>
 
+    <f:entry title="Framework ID" field="frameworkId">
+        <f:textbox readonly="readonly"/>
+    </f:entry>
+
     <f:entry title="Role" field="role">
         <f:textbox default="*" clazz="required"/>
     </f:entry>

--- a/src/test/java/org/jenkinsci/plugins/mesos/MesosCloudTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/MesosCloudTest.java
@@ -13,6 +13,8 @@ import com.mesosphere.utils.zookeeper.ZookeeperServerExtension;
 import hudson.util.XStream2;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.mesos.integration.MesosCloudProvisionTest;
 import org.junit.jupiter.api.Test;
@@ -56,5 +58,27 @@ public class MesosCloudTest {
             template -> {
               assertThat(template.getCpu(), is(notNullValue()));
             });
+  }
+
+  @Test
+  void serializationRoundTrip(TestUtils.JenkinsRule j)
+      throws IOException, InterruptedException, ExecutionException {
+    final MesosCloud cloud =
+        new MesosCloud(
+            mesosCluster.getMesosUrl().toString(),
+            "jenkins-framework",
+            "*",
+            "root",
+            j.getURL().toString(),
+            Collections.emptyList());
+
+    final XStream2 xstream = new XStream2();
+    final MesosCloud reloadedCloud = (MesosCloud) xstream.fromXML(xstream.toXML(cloud));
+
+    assertThat(reloadedCloud.getMesosMasterUrl(), is(equalTo(cloud.getMesosMasterUrl())));
+    assertThat(reloadedCloud.getFrameworkName(), is(equalTo(cloud.getFrameworkName())));
+    assertThat(reloadedCloud.getFrameworkId(), is(equalTo(cloud.getFrameworkId())));
+    assertThat(reloadedCloud.getRole(), is(equalTo(cloud.getRole())));
+    assertThat(reloadedCloud.getAgentUser(), is(equalTo(cloud.getAgentUser())));
   }
 }

--- a/src/test/java/org/jenkinsci/plugins/mesos/MesosCloudTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/MesosCloudTest.java
@@ -67,6 +67,7 @@ public class MesosCloudTest {
         new MesosCloud(
             mesosCluster.getMesosUrl().toString(),
             "jenkins-framework",
+            null,
             "*",
             "root",
             j.getURL().toString(),

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/DockerAgentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/DockerAgentTest.java
@@ -61,6 +61,7 @@ public class DockerAgentTest {
         new MesosCloud(
             mesosCluster.getMesosUrl().toString(),
             "MesosTest",
+            null,
             "*",
             System.getProperty("user.name"),
             j.getURL().toString(),

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosCloudProvisionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosCloudProvisionTest.java
@@ -74,6 +74,7 @@ public class MesosCloudProvisionTest {
         new MesosCloud(
             mesosCluster.getMesosUrl().toString(),
             "MesosTest",
+            null,
             "*",
             System.getProperty("user.name"),
             j.getURL().toString(),
@@ -123,6 +124,7 @@ public class MesosCloudProvisionTest {
         new MesosCloud(
             mesosCluster.getMesosUrl().toString(),
             "MesosTest",
+            null,
             "*",
             System.getProperty("user.name"),
             j.getURL().toString(),

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosJenkinsAgentLifecycleTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosJenkinsAgentLifecycleTest.java
@@ -43,6 +43,7 @@ public class MesosJenkinsAgentLifecycleTest {
         new MesosCloud(
             mesosCluster.getMesosUrl().toString(),
             "MesosTest",
+            null,
             "*",
             System.getProperty("user.name"),
             j.getURL().toString(),
@@ -71,6 +72,7 @@ public class MesosJenkinsAgentLifecycleTest {
         new MesosCloud(
             mesosCluster.getMesosUrl().toString(),
             "MesosTest",
+            null,
             "*",
             System.getProperty("user.name"),
             j.getURL().toString(),
@@ -101,6 +103,7 @@ public class MesosJenkinsAgentLifecycleTest {
         new MesosCloud(
             mesosCluster.getMesosUrl().toString(),
             "MesosTest",
+            null,
             "*",
             System.getProperty("user.name"),
             j.getURL().toString(),
@@ -129,6 +132,7 @@ public class MesosJenkinsAgentLifecycleTest {
         new MesosCloud(
             mesosCluster.getMesosUrl().toString(),
             "MesosTest",
+            null,
             "*",
             System.getProperty("user.name"),
             j.getURL().toString(),
@@ -157,6 +161,7 @@ public class MesosJenkinsAgentLifecycleTest {
         new MesosCloud(
             mesosCluster.getMesosUrl().toString(),
             "MesosTest",
+            null,
             "*",
             System.getProperty("user.name"),
             j.getURL().toString(),


### PR DESCRIPTION
Summary:
The plugin would create a new framework ID and a new Mesos connection if the config was
changed. This patch persists the framework ID in the config as a read only parameter.

Furthermore the plugin is now partition and region aware to support Windows fault domains.

We also test the serialization and deserialization.

Jira issues: DCOS_OSS-5831, DCOS_OSS-5817