### PR TITLE
Rename plugin dependency.

### DIFF
--- a/dcos/conf/plugins.conf
+++ b/dcos/conf/plugins.conf
@@ -18,7 +18,6 @@
   job-dsl:1.70                   
   jobConfigHistory:2.19          
   parameterized-trigger:2.35.2
-  pipeline:2.6
   plain-credentials:1.4
   rebuild:1.28                   
   role-strategy:2.9.0            
@@ -27,3 +26,4 @@
   scm-api:2.6.3
   ssh-agent:1.16                 
   ssh-slaves:1.28               
+  workflow-aggregator:2.6


### PR DESCRIPTION
Summary:
The Docker build would fail because the name of the pre-installed
pipeline plugin was wring.