### PR TITLE
Remove Jackson API plugin.

### DIFF
--- a/dcos/conf/plugins.conf
+++ b/dcos/conf/plugins.conf
@@ -14,7 +14,6 @@
   github-branch-source:2.3.6     
   github-organization-folder:1.6
   metrics:4.0.2.6
-  jackson2-api:2.8.11.3
   job-dsl:1.70                   
   jobConfigHistory:2.19          
   parameterized-trigger:2.35.2


### PR DESCRIPTION
Summary:
It's pulled in by downstream dependencies.