### PR TITLE
Change Mesos API on configuration change.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ test {
 }
 
 group = "org.jenkins-ci.plugins"
-version = "2.0-beta-13"
+version = "2.0-beta-14"
 description = "Allows the dynamic launch of Jenkins agent on a Mesos cluster, depending on workload"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ test {
 }
 
 group = "org.jenkins-ci.plugins"
-version = "2.0-beta-14"
+version = "2.0-beta-15"
 description = "Allows the dynamic launch of Jenkins agent on a Mesos cluster, depending on workload"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ test {
 }
 
 group = "org.jenkins-ci.plugins"
-version = "2.0-beta-15"
+version = "2.0-beta-16"
 description = "Allows the dynamic launch of Jenkins agent on a Mesos cluster, depending on workload"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -85,17 +85,22 @@ public class MesosApi {
       sessions.put(frameworkId, session);
     }
 
-    return sessions.get(frameworkId);
+    // Override Jenkins URL and agent user if they changed.
+    MesosApi session = sessions.get(frameworkId);
+    session.setJenkinsUrl(jenkinsUrl);
+    session.setAgentUser(agentUser);
+
+    return session;
   }
 
   private final Settings operationalSettings;
 
   private final String frameworkName;
   private final Optional<String> frameworkPrincipal;
-  private final String role;
-  private final String agentUser;
+  private String role;
+  private String agentUser;
   private final String frameworkId;
-  private final URL jenkinsUrl;
+  private URL jenkinsUrl;
   private Duration agentTimeout;
 
   // Interface to USI.
@@ -425,6 +430,16 @@ public class MesosApi {
         stateMap.remove(podStateEvent.id());
       }
     }
+  }
+
+  // Setters
+
+  public void setJenkinsUrl(URL jenkinsUrl) {
+    this.jenkinsUrl = jenkinsUrl;
+  }
+
+  public void setAgentUser(String user) {
+    this.agentUser = user;
   }
 
   /** test method to set the agent timeout duration */

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosApi.java
@@ -83,14 +83,14 @@ public class MesosApi {
               authorization);
       logger.info("Initialized Mesos API object.");
       sessions.put(frameworkId, session);
+      return session;
+    } else {
+      // Override Jenkins URL and agent user if they changed.
+      MesosApi session = sessions.get(frameworkId);
+      session.setJenkinsUrl(jenkinsUrl);
+      session.setAgentUser(agentUser);
+      return session;
     }
-
-    // Override Jenkins URL and agent user if they changed.
-    MesosApi session = sessions.get(frameworkId);
-    session.setJenkinsUrl(jenkinsUrl);
-    session.setAgentUser(agentUser);
-
-    return session;
   }
 
   private final Settings operationalSettings;

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/LaunchCommandBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/LaunchCommandBuilder.java
@@ -45,7 +45,7 @@ public class LaunchCommandBuilder {
   }
 
   private static final String LINUX_AGENT_COMMAND_TEMPLATE =
-      "java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar ${MESOS_SANDBOX-.}/agent.jar %s %s -jnlpUrl %s";
+      "wrapper.sh java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar ${MESOS_SANDBOX-.}/agent.jar %s %s -jnlpUrl %s"; // TODO(kjeschkies) wrapper.sh should only be used for Dind images.
   private static final String WINDOWS_AGENT_COMMAND_TEMPLATE =
       "java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar %%MESOS_SANDBOX%%/agent.jar %s %s -jnlpUrl %s";
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/LaunchCommandBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/LaunchCommandBuilder.java
@@ -45,7 +45,7 @@ public class LaunchCommandBuilder {
   }
 
   private static final String LINUX_AGENT_COMMAND_TEMPLATE =
-      "wrapper.sh java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar ${MESOS_SANDBOX-.}/agent.jar %s %s -jnlpUrl %s"; // TODO(kjeschkies) wrapper.sh should only be used for Dind images.
+      "java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar ${MESOS_SANDBOX-.}/agent.jar %s %s -jnlpUrl %s";
   private static final String WINDOWS_AGENT_COMMAND_TEMPLATE =
       "java -DHUDSON_HOME=jenkins -server -Xmx%dm %s -jar %%MESOS_SANDBOX%%/agent.jar %s %s -jnlpUrl %s";
 


### PR DESCRIPTION
Summary:
Changes to the Jenkins URL and agent user would have no effect since the
Mesos API needs to reconnect to Mesos and the URL need to be overriden
in case the connection was cached.

JIRA issues: DCOS_OSS-5933