### PR TITLE
Use Docker entrypoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ is automatically shut down.
   - __[Pipeline jobs](#pipeline-jobs)__
 - __[Plugin Development](#plugin-development)__
   - __[Building the plugin](#building-the-plugin)__
-  - __[On DC/OS Enterprise](#on-dcos-enterprise)__
+  - __[Testing On DC/OS Enterprise](#testing-on-dcos-enterprise)__
+- __[Release](#release)__
 <!-- /toc -->
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.33-a275fdd-SNAPSHOT'
+    usiVersion= '0.1.33-a09b653-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.33-a72b8fe-SNAPSHOT'
+    usiVersion= '0.1.33-6b41f65-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }
@@ -58,7 +58,7 @@ test {
 }
 
 group = "org.jenkins-ci.plugins"
-version = "2.0-beta-16"
+version = "2.0-beta-18"
 description = "Allows the dynamic launch of Jenkins agent on a Mesos cluster, depending on workload"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.32'
+    usiVersion= '0.1.33-a275fdd-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.33-a09b653-SNAPSHOT'
+    usiVersion= '0.1.33-a72b8fe-SNAPSHOT'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.33-6b41f65-SNAPSHOT'
+    usiVersion= '0.1.35'
     scalaVersion = '2.12'
     akkaVersion = '2.5.19'
 }

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/RunTemplateFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/RunTemplateFactory.java
@@ -61,7 +61,7 @@ public class RunTemplateFactory {
       Optional<MesosAgentSpecTemplate.ContainerInfo> containerInfo) {
 
     // If a container info is set we assume its Docker image defines and entrypoint.
-    Command cmd = containerInfo.isPresent() ? DockerEntrypoint.create(shellCommand) : new Shell(shellCommand);
+    final Command cmd = (containerInfo.isPresent() ? DockerEntrypoint.create(shellCommand) : new Shell(shellCommand));
 
     TaskBuilder taskBuilder =
         SimpleTaskInfoBuilder.create(

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/RunTemplateFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/RunTemplateFactory.java
@@ -10,11 +10,10 @@ import com.mesosphere.usi.core.models.template.FetchUri;
 import com.mesosphere.usi.core.models.template.LegacyLaunchRunTemplate;
 import com.mesosphere.usi.core.models.template.RunTemplate;
 import com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory.Command;
+import com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory.DockerEntrypoint$;
 import com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory.Shell;
 import com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory.SimpleTaskInfoBuilder;
-import com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory.DockerEntrypoint;
-import java.util.Arrays;
-import java.util.Collections;
+import com.mesosphere.usi.core.models.template.SimpleRunTemplateFactory.SimpleTaskInfoBuilder$;
 import java.util.List;
 import java.util.Optional;
 import org.apache.mesos.v1.Protos.ContainerInfo;
@@ -30,7 +29,6 @@ import org.jenkinsci.plugins.mesos.MesosAgentSpecTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
-import scala.collection.JavaConverters;
 import scala.collection.Seq;
 import scala.collection.immutable.Map;
 
@@ -61,15 +59,13 @@ public class RunTemplateFactory {
       Optional<MesosAgentSpecTemplate.ContainerInfo> containerInfo) {
 
     // If a container info is set we assume its Docker image defines and entrypoint.
-    final Command cmd = (containerInfo.isPresent() ? DockerEntrypoint.create(shellCommand) : new Shell(shellCommand));
+    final Command cmd =
+        containerInfo.isPresent()
+            ? DockerEntrypoint$.MODULE$.create(shellCommand)
+            : new Shell(shellCommand);
 
     TaskBuilder taskBuilder =
-        SimpleTaskInfoBuilder.create(
-            requirements,
-            cmd,
-            role,
-            fetchUris,
-            Option.empty());
+        SimpleTaskInfoBuilder$.MODULE$.create(requirements, cmd, role, fetchUris, Option.empty());
     if (containerInfo.isPresent()) {
       taskBuilder = new ContainerInfoTaskInfoBuilder(agentName, taskBuilder, containerInfo.get());
     }

--- a/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
@@ -45,7 +45,7 @@ public class AgentSpecMother {
           Collections.emptyList(),
           new ContainerInfo(
               "DOCKER",
-              "mesosphere/jenkins-dind:0.6.0-alpine",
+              "mesosphere/jenkins-dind-dev:karsten",
               true,
               true,
               false,

--- a/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
@@ -48,7 +48,7 @@ public class AgentSpecMother {
               "mesosphere/jenkins-dind-dev:karsten",
               true,
               true,
-              false,
+              true,
               Collections.emptyList(),
               Network.HOST),
           null,

--- a/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
@@ -48,7 +48,7 @@ public class AgentSpecMother {
               "mesosphere/jenkins-dind-dev:karsten",
               true,
               true,
-              true,
+              false,
               Collections.emptyList(),
               Network.HOST),
           null,

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/DockerAgentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/DockerAgentTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.mesos.integration;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -72,6 +73,7 @@ public class DockerAgentTest {
     MesosJenkinsAgent agent = (MesosJenkinsAgent) cloud.startAgent(name, spec).get();
 
     // verify slave is running when the future completes;
+    await().atMost(5, TimeUnit.MINUTES).until(agent::isRunning);
     assertThat(agent.isRunning(), is(true));
   }
 }


### PR DESCRIPTION
Summary:
If a Docker container is defined we pass the agent command as arguments
to the container. This way users will not have override the shell command.

Relates to https://github.com/mesosphere/dcos-jenkins-service/pull/319.

JIRA issues: DCOS_OSS-5937