### PR TITLE
select default mesos slave attributes on label match partial match

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/JenkinsScheduler.java
@@ -49,6 +49,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static org.apache.mesos.Protos.ContainerInfo.Type.MESOS;
 import static org.apache.mesos.Protos.Image.Type.DOCKER;
@@ -625,7 +626,9 @@ public class JenkinsScheduler implements Scheduler {
         double requestedCpus = request.request.cpus;
         double requestedMem = (1 + JVM_MEM_OVERHEAD_FACTOR) * request.request.mem;
         // Get matching slave attribute for this label.
-        JSONObject slaveAttributes = getMesosCloud().getSlaveAttributeForLabel(request.request.slaveInfo.getLabelString());
+        LOGGER.info("Get slave attributes for label: " + request.request.slaveInfo.getLabelString());
+        String defaultLabel = getLabelOrDefault(request);
+        JSONObject slaveAttributes = getSlaveAttributeForLabel(defaultLabel);
 
         if (requestedCpus <= cpus
                 && requestedMem <= mem
@@ -648,6 +651,66 @@ public class JenkinsScheduler implements Scheduler {
                             "  attributes:  " + (slaveAttributes == null ? ""  : slaveAttributes.toString()));
             return false;
         }
+    }
+
+    /**
+     * Retrieves the slaveAttributes corresponding to label name. In the event of a match on label names,
+     * returns attributes for SlaveInfo marked as default, otherwiese the matched label's slave attributes. Keeping with
+     * the previous behavior, will return null/empty slave attributes.
+     * @param labelName MesosSlaveInfo label string name.
+     * @return slaveAttributes as a JSONObject.
+     */
+
+    private JSONObject getSlaveAttributeForLabel(String labelName) {
+        LOGGER.info(String.format("Getting slave attributes for label: %s", labelName));
+        List<MesosSlaveInfo> matchedSlaves = getMesosCloud().getSlaveInfos().stream()
+                .filter(slaveInfo -> slaveInfo.getLabelString() != null && slaveInfo.getLabelString().equals(labelName))
+                .collect(Collectors.toList());
+
+        if (matchedSlaves.size() > 1) {
+            LOGGER.info(String.format("Multiple matches for label %s found, matches: %o", labelName, matchedSlaves.size()));
+            LOGGER.info("For multiple matches, checking for Slave Info marked as default");
+            return matchedSlaves.stream()
+                    .filter(MesosSlaveInfo::isDefaultSlave).collect(Collectors.toList())
+                    .stream()
+                    .findFirst()
+                    .map(MesosSlaveInfo::getSlaveAttributes)
+                    .orElse(null);
+        }
+        return matchedSlaves.stream().findFirst().map(MesosSlaveInfo::getSlaveAttributes).orElse(null);
+    }
+
+    /**
+     * Checks for label to match based upon provided label, in the event that label is not found then determine closest
+     * matching label. First checks for exact match of label, on exact match return it. Secondly, will trim label (ex: mesos:myDockerContainer)
+     * then checks for a match of trimmed label and returns it. If no match is found return original reqLabel.
+     * @param request
+     * @return label
+     */
+    private String getLabelOrDefault(Request request) {
+        String reqLabel = request.request.slaveInfo.getLabelString();
+        boolean match = getMesosCloud().getSlaveInfos().stream().anyMatch(slaveInfo -> {
+            assert slaveInfo.getLabelString() != null;
+            return slaveInfo.getLabelString().equals(reqLabel);
+        });
+
+        if (match || reqLabel == null) {
+            return reqLabel;
+        }
+
+        String trimmedLabel = reqLabel.split(":")[0];
+        List<String> sortedLabelList = getMesosCloud().getSlaveInfos()
+                .stream()
+                .map(MesosSlaveInfo::getLabelString)
+                .sorted(Collections.reverseOrder())
+                .collect(Collectors.toList());
+
+        match = sortedLabelList.stream().anyMatch(label -> label.equals(trimmedLabel));
+         if(match){
+             return trimmedLabel;
+         } else {
+            return reqLabel;
+         }
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -663,22 +663,6 @@ public class MesosCloud extends Cloud {
     return null;
   }
 
-  /**
-  * Retrieves the slaveattribute corresponding to label name.
-  *
-  * @param labelName The Jenkins label name.
-  * @return slaveattribute as a JSONObject.
-  */
-
-  public JSONObject getSlaveAttributeForLabel(String labelName) {
-    for (MesosSlaveInfo slaveInfo : slaveInfos) {
-      if (StringUtils.equals(labelName, slaveInfo.getLabelString())) {
-          return slaveInfo.getSlaveAttributes();
-      }
-    }
-    return null;
-  }
-
   protected Object readResolve() {
     migrateToCredentials();
     if (role == null) {


### PR DESCRIPTION
- In situation where developers are using Configuration as Code, and specifying mesos label in scripted DSL (ex: mesos:myDockerContainer) would require label creation for N number of docker containers to be configured in Mesos Cloud config. Was observing in this case, slave attributes were not being honored and offers were accepted regardless.
- Introduce enhancement to label matching to retrieve attributes, so in event of match on primary label configured as default (ex: mesos) for request(mesos:myDockerContainer) would match based on enhancement which first attempts to get exact match, then trims label provided to find a match also marked as default or otherwise, like previously, just return the provided label's attributes. 
- this enhancement provides to maintainers the ability to support slave info defaults in the event that users of the system want to use the default mesos attributes but would like to customize docker container being used.
- Added UTs to test previous behavior still intact, as well as testing the enhancements.