### PR TITLE
Fix DockerAgentTest.

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,0 +1,4 @@
+FROM amazoncorretto:8u252
+
+ENTRYPOINT ["/bin/bash"]
+CMD []

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,4 +1,4 @@
 FROM amazoncorretto:8u252
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/bash", "-c"]
 CMD []

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,10 +4,9 @@ node('docker') {
 
       try {
         checkout scm
-        sh 'sudo mkdir -p local_docker_storage'
-        sh 'sudo -E docker run -d --rm --privileged -v "$(pwd):/var/build" -v local_docker_storage:/var/lib/docker --name mini mesos/mesos-mini:1.9.x'
+        sh 'sudo -E docker run -d --rm --privileged -v "$(pwd):/var/build" --name mini mesos/mesos-mini:1.9.x'
 	timeout(time: 45, unit: 'MINUTES') {
-          sh 'sudo -E docker exec --privileged -w /var/build mini ci/run.sh'
+          sh 'sudo -E docker exec -w /var/build mini ci/run.sh'
 	}
       } finally {
         // Compress and archive sandboxes, JUnit and Spotbugs reports.
@@ -21,7 +20,6 @@ node('docker') {
 
         // Kill Mini Mesos last so we have everything archived in case of an error.
         sh 'sudo docker kill mini'
-        sh 'sudo rm -rf local_docker_storage'
       }
     } 
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,18 +3,22 @@ node('docker') {
     stage('Build') {
       try {
         checkout scm
-        sh 'sudo -E docker run -d --rm --privileged -v "$(pwd):/var/build" --name mini mesos/mesos-mini:1.9.x'
-        sh 'sudo -E docker exec -w /var/build mini ci/run.sh'
+        sh 'sudo mkdir -p local_docker_storage'
+        sh 'sudo -E docker run -d --rm --privileged -v "$(pwd):/var/build" -v local_docker_storage:/var/lib/docker --name mini mesos/mesos-mini:1.9.x'
+        sh 'sudo -E docker exec --privileged -w /var/build mini ci/run.sh'
       } finally {
-        sh 'sudo docker kill mini'
-        junit allowEmptyResults: true, testResults: 'build/test-results/test/*.xml'
-
-        // Compress and archive sandboxes.
+        // Compress and archive sandboxes, JUnit and Spotbugs reports.
         sh 'sudo -E ./gradlew zipSandboxes --info'
         sh 'sudo rm -rf sandboxes'
         archive includes: 'build/distributions/sandboxes-*.zip'
 
+        junit allowEmptyResults: true, testResults: 'build/test-results/test/*.xml'
+
         publishHTML (target: [ alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'build/reports/spotbugs/', reportFiles: '*.html', reportName: 'SpotBugs' ])
+
+        // Kill Mini Mesos last so we have everything archived in case of an error.
+        sh 'sudo docker kill mini'
+        sh 'sudo rm -rf local_docker_storage'
       }
     } 
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,14 @@
 #!/usr/bin/env groovy
 node('docker') {
     stage('Build') {
+
       try {
         checkout scm
         sh 'sudo mkdir -p local_docker_storage'
         sh 'sudo -E docker run -d --rm --privileged -v "$(pwd):/var/build" -v local_docker_storage:/var/lib/docker --name mini mesos/mesos-mini:1.9.x'
-        sh 'sudo -E docker exec --privileged -w /var/build mini ci/run.sh'
+	timeout(time: 45, unit: 'MINUTES') {
+          sh 'sudo -E docker exec --privileged -w /var/build mini ci/run.sh'
+	}
       } finally {
         // Compress and archive sandboxes, JUnit and Spotbugs reports.
         sh 'sudo -E ./gradlew zipSandboxes --info'

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ test {
 }
 
 group = "org.jenkins-ci.plugins"
-version = "2.0-beta-18"
+version = "2.0-beta-19"
 description = "Allows the dynamic launch of Jenkins agent on a Mesos cluster, depending on workload"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/dcos-testing/conf/jenkins/configuration.yaml
+++ b/dcos-testing/conf/jenkins/configuration.yaml
@@ -14,9 +14,9 @@ jenkins:
             agentCommandStyle: Linux
             containerInfo:
               dockerForcePullImage: false
-              dockerImage: "amazoncorretto:8"
-              dockerPrivilegedMode: false
-              isDind: false
+              dockerImage: "mesosphere/jenkins-dind:0.8.0"
+              dockerPrivilegedMode: true
+              isDind: true
               networking: HOST
               type: "DOCKER"
             cpus: "0.1"

--- a/src/main/java/org/jenkinsci/plugins/mesos/api/RunTemplateFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/api/RunTemplateFactory.java
@@ -56,7 +56,7 @@ public class RunTemplateFactory {
       List<FetchUri> fetchUris,
       Optional<MesosAgentSpecTemplate.ContainerInfo> containerInfo) {
 
-    // If a container info is set we assume its Docker image defines and entrypoint.
+    // If a container info is set we assume its Docker image defines an entrypoint.
     TaskBuilder taskBuilder;
     if (containerInfo.isPresent()) {
       taskBuilder =

--- a/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
@@ -48,7 +48,7 @@ public class AgentSpecMother {
               "jeschkies/jenkins-simple-agent:testing",
               false,
               false,
-              false,
+              true,
               Collections.emptyList(),
               Network.HOST),
           null,

--- a/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
@@ -45,7 +45,7 @@ public class AgentSpecMother {
           Collections.emptyList(),
           new ContainerInfo(
               "DOCKER",
-              "mesosphere/jenkins-dind-dev:karsten",
+              "mesosphere/jenkins-dind:0.8.0",
               true,
               true,
               false,

--- a/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
@@ -45,9 +45,9 @@ public class AgentSpecMother {
           Collections.emptyList(),
           new ContainerInfo(
               "DOCKER",
-              "mesosphere/jenkins-dind:0.8.0",
-              true,
-              true,
+              "jeschkies/jenkins-simple-agent:testing",
+              false,
+              false,
               false,
               Collections.emptyList(),
               Network.HOST),


### PR DESCRIPTION
Summary:
The previous image would try to start a Docker daemon in a Docker container which itself is
running in a Docker container on the CI. This could work but just takes too much configuration.
We are running a simple client instead.