### PR TITLE
Mesos Agents are not reusable (#408)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Ignore Gradle build output directory
 build
+target
 
 # Ignore Jenkins work dir
 work

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ immediately scheduled! Similarly, when a Jenkins slave is idle for a long time i
 is automatically shut down.
 
 ## Table of Contents
-<!-- toc -->
-- __[Prerequisite](#prerequisite)__
+<!-- toc -->- __[Prerequisite](#prerequisite)__
 - __[Installing the Plugin](#installing-the-plugin)__
   - __[Configuring the Plugin](#configuring-the-plugin)__
   - __[Adding Agent Specs](#adding-agent-specs)__

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,11 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.54'
+    usiVersion= '0.1.48'
     scalaVersion = '2.13'
     akkaVersion = '2.6.3'
     junitJupiterVersion = '5.6.2'
-    jcascVersion = '2.0.1'
+    jcascVersion = '1.35'
 }
 
 dependencies {
@@ -41,9 +41,9 @@ dependencies {
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
     api group: 'com.typesafe.akka', name: "akka-slf4j_$scalaVersion", version: akkaVersion
 
-    jenkinsPlugins 'org.jenkins-ci.plugins:metrics:4.0.2.6@jar'
-    jenkinsServer 'org.jenkins-ci.plugins:metrics:4.0.2.6'
-    testRuntimeOnly 'org.jenkins-ci.plugins:metrics:4.0.2.6'
+    jenkinsPlugins 'org.jenkins-ci.plugins:metrics:4.0.2.5@jar'
+    jenkinsServer 'org.jenkins-ci.plugins:metrics:4.0.2.5'
+    testRuntimeOnly 'org.jenkins-ci.plugins:metrics:4.0.2.5'
 
     // Test dependencies
     testImplementation 'com.squareup.okhttp3:okhttp:3.14.1'

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,11 @@ repositories {
 }
 
 ext {
-    usiVersion= '0.1.48'
+    usiVersion= '0.1.54'
     scalaVersion = '2.13'
     akkaVersion = '2.6.3'
     junitJupiterVersion = '5.6.2'
-    jcascVersion = '1.35'
+    jcascVersion = '2.0.1'
 }
 
 dependencies {
@@ -41,9 +41,9 @@ dependencies {
     api group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
     api group: 'com.typesafe.akka', name: "akka-slf4j_$scalaVersion", version: akkaVersion
 
-    jenkinsPlugins 'org.jenkins-ci.plugins:metrics:4.0.2.5@jar'
-    jenkinsServer 'org.jenkins-ci.plugins:metrics:4.0.2.5'
-    testRuntimeOnly 'org.jenkins-ci.plugins:metrics:4.0.2.5'
+    jenkinsPlugins 'org.jenkins-ci.plugins:metrics:4.0.2.6@jar'
+    jenkinsServer 'org.jenkins-ci.plugins:metrics:4.0.2.6'
+    testRuntimeOnly 'org.jenkins-ci.plugins:metrics:4.0.2.6'
 
     // Test dependencies
     testImplementation 'com.squareup.okhttp3:okhttp:3.14.1'
@@ -85,7 +85,7 @@ task integrationTest(type: Test) {
 }
 
 group = "org.jenkins-ci.plugins"
-version = "2.0"
+version = "2.0.1"
 description = "Allows the dynamic launch of Jenkins agent on a Mesos cluster, depending on workload"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate.java
@@ -58,6 +58,7 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
   public MesosAgentSpecTemplate(
       String label,
       Node.Mode mode,
+      boolean reusable,
       String cpus,
       String mem,
       int idleTerminationMinutes,
@@ -73,7 +74,7 @@ public class MesosAgentSpecTemplate extends AbstractDescribableImpl<MesosAgentSp
     this.label = label;
     this.mode = mode;
     this.idleTerminationMinutes = idleTerminationMinutes;
-    this.reusable = false; // TODO: DCOS_OSS-5048.
+    this.reusable = reusable;
     this.cpus = (cpus != null) ? Double.parseDouble(cpus) : 0.1;
     this.mem = Integer.parseInt(mem);
     this.minExecutors = minExecutors;

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosJenkinsAgent.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosJenkinsAgent.java
@@ -80,9 +80,9 @@ public class MesosJenkinsAgent extends AbstractCloudSlave implements EphemeralNo
   }
 
   @Extension
-  public static final class DescriptorImpl extends NodeDescriptor {
+  public static final class DescriptorImpl extends SlaveDescriptor {
     public String getDisplayName() {
-      return "";
+      return "MesosJenkinsAgent";
     }
   }
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosSlaveInfo.java
@@ -27,6 +27,7 @@ public class MesosSlaveInfo {
   private static final Logger logger = LoggerFactory.getLogger(MesosSlaveInfo.class);
 
   private transient Node.Mode mode;
+  private transient boolean reusable;
   private transient String labelString;
   private transient Double slaveCpus;
   private transient Double diskNeeded;
@@ -73,6 +74,7 @@ public class MesosSlaveInfo {
     return new MesosAgentSpecTemplate(
         this.labelString,
         this.mode,
+        this.reusable,
         this.slaveCpus.toString(),
         Integer.toString(this.slaveMem),
         this.idleTerminationMinutes,

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/config.jelly
@@ -10,6 +10,10 @@
 
         <f:slave-mode name="mode" node="${instance}" />
 
+        <f:entry title="${%Jenkins Agent Reusable}" field="reusable">
+                <f:checkbox clazz="required" default="false"/>
+        </f:entry>
+
         <f:entry title="${%Jenkins Agent CPUs}" field="cpus">
                 <f:textbox clazz="required" default="0.1"/>
         </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/help-reusable.html
+++ b/src/main/resources/org/jenkinsci/plugins/mesos/MesosAgentSpecTemplate/help-reusable.html
@@ -1,0 +1,3 @@
+<div>
+  Can Jenkins Agents be reused by the Mesos cluster.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/fixture/AgentSpecMother.java
@@ -17,6 +17,7 @@ public class AgentSpecMother {
       new MesosAgentSpecTemplate(
           "label",
           Mode.EXCLUSIVE,
+          false,
           "0.1",
           "32",
           1,
@@ -34,6 +35,7 @@ public class AgentSpecMother {
       new MesosAgentSpecTemplate(
           "label",
           Mode.EXCLUSIVE,
+          false,
           "0.5",
           "512",
           3,

--- a/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosCloudProvisionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mesos/integration/MesosCloudProvisionTest.java
@@ -58,6 +58,7 @@ public class MesosCloudProvisionTest {
         new MesosAgentSpecTemplate(
             label.toString(),
             Mode.EXCLUSIVE,
+            false,
             "0.1",
             "32",
             idleMin,
@@ -108,6 +109,7 @@ public class MesosCloudProvisionTest {
         new MesosAgentSpecTemplate(
             label.toString(),
             Mode.EXCLUSIVE,
+            false,
             "0.1",
             "32",
             idleMin,


### PR DESCRIPTION
Added configuration for Agent reusable flag.

Most of the changes are related to exposing the 'reusable' properties as a checkbox in the configuration page.
Not sure if the version changes will cause an issue? They were the versions I was compiling against.

I've run this in my Mesos 1.9 system and I see the Jenkins Agents being reused if they exist.

Regards,
Chris. 