### PR TITLE
Remove usage of `--ajp13Port`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,5 @@ CMD envsubst '\$PORT0 \$PORT1 \$JENKINS_CONTEXT' < /etc/nginx/nginx.conf.templat
      ${JENKINS_OPTS}                                 \
      --httpPort=${PORT1}                             \
      --webroot=${JENKINS_FOLDER}/war                 \
-     --ajp13Port=-1                                  \
      --httpListenAddress=127.0.0.1                   \
-     --ajp13ListenAddress=127.0.0.1                  \
      --prefix=${JENKINS_CONTEXT}


### PR DESCRIPTION
AJP support was removed in Jetty 9 and Winstone 3.0 in https://github.com/jenkinsci/winstone/pull/22, never to return. As a result it is pointless to keep setting this option.