### PR TITLE
[JENKINS-71737] make MesosCloud name uneditable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 jenkinsPlugin {
-    coreVersion = "2.423-rc34199.8c3d6c65b_758"
+    coreVersion = "2.164"
     displayName = "Mesos Cloud"
     shortName = "mesos-cloud"
     url = "https://wiki.jenkins-ci.org/display/JENKINS/Mesos+Plugin"

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 jenkinsPlugin {
-    coreVersion = "2.164"
+    coreVersion = "2.423-rc34199.8c3d6c65b_758"
     displayName = "Mesos Cloud"
     shortName = "mesos-cloud"
     url = "https://wiki.jenkins-ci.org/display/JENKINS/Mesos+Plugin"

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -145,10 +145,11 @@ public class MesosCloud extends AbstractCloudImpl {
         this.master);
   }
 
-  @Override
-  boolean isNameEditable() {
-    return false;
-  }
+//  TODO: Uncomment when https://github.com/jenkinsci/jenkins/pull/8310 has been merged and released
+//  @Override
+//  boolean isNameEditable() {
+//    return false;
+//  }
 
   private Object readResolve() throws IOException {
 

--- a/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/mesos/MesosCloud.java
@@ -145,6 +145,11 @@ public class MesosCloud extends AbstractCloudImpl {
         this.master);
   }
 
+  @Override
+  boolean isNameEditable() {
+    return false;
+  }
+
   private Object readResolve() throws IOException {
 
     // Migration from 1.x


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
downstream of https://github.com/jenkinsci/jenkins/pull/8310

Setting `MesosCloud.isNameEditable()` to `false`. This will disable the cloud rename page.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
